### PR TITLE
Uncomment integration tests from Travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
         - STREAMR_HTTP_URL: http://localhost:8081/streamr-core/api/v1
         - STREAMR_NODE_ADDRESS: "0xc0dBcc4e7a0e0BEF78Da67AC2CD5Ca2Dd3c4C165"
       script:
+        - ./node_modules/.bin/etherlime opt-out
         - sudo /etc/init.d/mysql stop
         - git clone https://github.com/streamr-dev/streamr-docker-dev.git
         - sudo ifconfig docker0 10.200.10.1/24

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ jobs:
         - STREAMR_HTTP_URL: http://localhost:8081/streamr-core/api/v1
         - STREAMR_NODE_ADDRESS: "0xc0dBcc4e7a0e0BEF78Da67AC2CD5Ca2Dd3c4C165"
       script:
-        - curl http://localhost:8081/streamr-core/api/v1/categories
         - sudo /etc/init.d/mysql stop
         - git clone https://github.com/streamr-dev/streamr-docker-dev.git
         - sudo ifconfig docker0 10.200.10.1/24
         - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 1"
-        - sleep 1m
+        - sleep 20s
         - docker ps
         - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start engine-and-editor"
         - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start ganache"
-        - sleep 5m
+        - sleep 2m
+        - curl http://localhost:8081/streamr-core/api/v1/categories
         - docker ps
         - docker logs streamr_nginx_reverse
         - ./node_modules/.bin/mocha test/integration/streamrChannel.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
         - STREAMR_HTTP_URL: http://localhost:8081/streamr-core/api/v1
         - STREAMR_NODE_ADDRESS: "0xc0dBcc4e7a0e0BEF78Da67AC2CD5Ca2Dd3c4C165"
       script:
+        - curl http://localhost:8081/streamr-core/api/v1/categories
         - sudo /etc/init.d/mysql stop
         - git clone https://github.com/streamr-dev/streamr-docker-dev.git
         - sudo ifconfig docker0 10.200.10.1/24
@@ -34,7 +35,8 @@ jobs:
         - sleep 5m
         - docker ps
         - docker logs streamr_nginx_reverse
-        - npm run integration-tests
+        - ./node_modules/.bin/mocha test/integration/streamrChannel.js
+        - ./node_modules/.bin/mocha test/integration/channel-runner.js
     - stage: "Build docker (dev)"
       if: tag IS blank
       install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,26 @@ jobs:
   include:
     - stage: "lint & unit tests"
       script:
-        - "npm run lint"
-        - "npm run unit-tests"
-    # - stage: "integration tests"
-    #   env:
-    #     - STREAMR_WS_URL: ws://localhost:8890/api/v1/ws
-    #     - STREAMR_HTTP_URL: http://localhost:8081/streamr-core/api/v1
-    #     - STREAMR_NODE_ADDRESS: "0xc0dBcc4e7a0e0BEF78Da67AC2CD5Ca2Dd3c4C165"
-    #   script:
-    #     - sudo /etc/init.d/mysql stop
-    #     - git clone https://github.com/streamr-dev/streamr-docker-dev.git
-    #     - sudo ifconfig docker0 10.200.10.1/24
-    #     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 1"
-    #     - sleep 1m
-    #     - docker ps
-    #     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start engine-and-editor"
-    #     - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start ganache"
-    #     - sleep 5m
-    #     - docker ps
-    #     - "npm run integration-tests"
+        - npm run lint
+        - npm run unit-tests
+    - stage: "integration tests"
+      env:
+        - STREAMR_WS_URL: ws://localhost:8890/api/v1/ws
+        - STREAMR_HTTP_URL: http://localhost:8081/streamr-core/api/v1
+        - STREAMR_NODE_ADDRESS: "0xc0dBcc4e7a0e0BEF78Da67AC2CD5Ca2Dd3c4C165"
+      script:
+        - sudo /etc/init.d/mysql stop
+        - git clone https://github.com/streamr-dev/streamr-docker-dev.git
+        - sudo ifconfig docker0 10.200.10.1/24
+        - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start 1"
+        - sleep 1m
+        - docker ps
+        - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start engine-and-editor"
+        - "$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh start ganache"
+        - sleep 5m
+        - docker ps
+        - docker logs streamr_nginx_reverse
+        - npm run integration-tests
     - stage: "Build docker (dev)"
       if: tag IS blank
       install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,19 @@ env:
     - secure: RPyQPPpqRa6irtrMTAeSnaL05I+34vHBAxZuoi+Fro7zbOXqFZOf4wy3vzNFtcfyBavvrVyAIsfDqY2woTZBCHwXhqAIUfxadcvYYU1eRvV6QJwPQtDI5cXo2p43JbJNn4uB2wqE4Q2mbOegzSXBAd8ykNKkdmYyTdvOMpkn3AH5pQ59KMQ8+DA0Z6uDxZcORBiUq29LQY7jmO3EeSGXsdazDP66ETu/VKf1oArm+FWhQB0ylK3ZlfTUKwXyCKMeGl+7DMSIbp1iGPjkO8H4T6u9pdV1q5oxIwInzjCRLYFglhBrS66fePojp/jtDZvG3ISSr2BKq73qBk7s2RO/8ZrWVDbjdIUePpOzi/UZqobqvfod4nsb97ejUJgzm0kCIRvgO0ZukaZtNx+DSCsrFzqzQ+H6cWD98kCIHWjnOG0LIjK5g59vDtyyEsjVdTMTOSD3/H0txNSKRHjAoR0bc53yirZrefK4GBiSgwiSSfylk4AamCQLis2ZhkJEcaK2MTM+K5b8rHS7zAV8PFb0YO50DNvDkjgKNpRPWyT3Nyt+2UoIsjJe9jr5S/IlNL2Ic7+VB8U3zT7taeQKBxZXPrcyYB2AvAJZCXiTFXXmDuEZLAbOkhYDektdsyp3+3XahgmLycfgh6WJAZ6gdj9j2YFzX65x+gss7rS89x1lVPo=
 jobs:
   include:
-    - stage: "lint & unit tests"
+    - stage: "lint & tests"
+      env:
+        - JOB: LINT
       script:
         - npm run lint
-        - npm run unit-tests
-    - stage: "integration tests"
+    - stage: "lint & tests"
       env:
+        - JOB: UNIT-TESTS
+      script:
+        - npm run unit-tests
+    - stage: "lint & tests"
+      env:
+        - JOB: INTEGRATION-TESTS
         - STREAMR_WS_URL: ws://localhost:8890/api/v1/ws
         - STREAMR_HTTP_URL: http://localhost:8081/streamr-core/api/v1
         - STREAMR_NODE_ADDRESS: "0xc0dBcc4e7a0e0BEF78Da67AC2CD5Ca2Dd3c4C165"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "start_server.js",
   "scripts": {
     "start": "node start_server.js",
-    "postinstall": "./node_modules/.bin/etherlime opt-out || true",
     "lint": "./node_modules/.bin/eslint *.js src test",
     "flatten": "./node_modules/.bin/etherlime --solcVersion=0.4.24 flatten CommunityProduct.sol",
     "build-contracts": "./node_modules/.bin/etherlime --solcVersion=0.4.24 compile",

--- a/test/utils/await-until.js
+++ b/test/utils/await-until.js
@@ -28,7 +28,7 @@ async function untilStreamContains(stream, target) {
     return new Promise(done => {
         function handler(data) {
             if (data.includes(target)) {
-                stream.off("data", handler)
+                stream.off && stream.off("data", handler)
                 done(data.toString())
             }
         }
@@ -48,7 +48,7 @@ async function untilStreamMatches(stream, regex) {
             const data = buffer.toString()
             const match = data.match(regex)
             if (match) {
-                stream.off("data", check)
+                stream.off && stream.off("data", check)
                 done(match)
             }
         }
@@ -73,7 +73,7 @@ async function capture(stream, regex, count = 1) {
                 const newMatches = fullMatches.map(s => s.match(regex)[1])
                 matches = matches.concat(newMatches).slice(0, count)
                 if (matches.length >= count) {
-                    stream.off("data", check)
+                    stream.off && stream.off("data", check)
                     done(matches)
                 }
             }


### PR DESCRIPTION
Started a PR just so to heckle Travis into building it.

The main challenge now is to set up Travis so that e.g. streamrChannel tests (that are fairly simple) would pass.

Then work up to getting `test/integration/engine-and-editor-api.js` pass, then write integration test using streamr-client (only, if possible; possibly augment streamr-client so that it IS possible)