### PR TITLE
Fix Docker permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,12 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /
 ENV PATH="/node-$NODE_VERSION-linux-x64/bin:${PATH}"
-COPY --from=builder /node-$NODE_VERSION-linux-x64/ /node-$NODE_VERSION-linux-x64/
+COPY --from=builder --chown=root:root /node-$NODE_VERSION-linux-x64/ /node-$NODE_VERSION-linux-x64/
 
 RUN useradd -ms /bin/bash node
 USER node
 WORKDIR /home/node
-COPY --from=builder /home/node/ ./
+COPY --from=builder --chown=node:node /home/node/ ./
 
 ENV WEBSERVER_PORT=8085
 ENV STREAMR_WS_URL="ws://localhost:8890/api/v1/ws"


### PR DESCRIPTION
Fix ENOENT

```
streamr_dev_cp              | 2020-01-22T11:32:18.484185500Z (node:7) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, mkdir '/home/node/scripts/store/0x5159FBF2e0Ff63e35b17293416fdf7a0909a0cDA'
```