### PR TITLE
Add http logging with morgan.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,6 +1747,14 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -18122,6 +18130,7 @@
               "requires": {
                 "debug": "^2.2.0",
                 "es5-ext": "^0.10.50",
+                "gulp": "^4.0.2",
                 "nan": "^2.14.0",
                 "typedarray-to-buffer": "^3.1.5",
                 "yaeti": "^0.0.6"
@@ -20396,6 +20405,28 @@
         }
       }
     },
+    "morgan": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "mout": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
@@ -20696,6 +20727,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "4.17.1",
     "ganache-cli": "6.7.0",
     "monoplasma": "0.1.10",
+    "morgan": "1.9.1",
     "mz": "2.7.0",
     "streamr-client": "2.2.7"
   },

--- a/scripts/start_server.js
+++ b/scripts/start_server.js
@@ -4,6 +4,7 @@ const fs = require("mz/fs")
 const express = require("express")
 const cors = require("cors")
 const bodyParser = require("body-parser")
+const morgan = require("morgan")
 const onProcessExit = require("exit-hook")
 
 const {
@@ -156,8 +157,10 @@ async function start() {
         const port = WEBSERVER_PORT
         const serverURL = `http://localhost:${port}`
         const app = express()
+        app.use(morgan("combined"))
         app.use(cors())
         app.use(bodyParser.json({limit: "50mb"}))
+
         app.get("/config", (req, res) => { res.send(config) }) // TODO: remove
         app.use("/communities", getCommunitiesRouter(server))
         app.listen(port, () => log(`Web server started at ${serverURL}`))


### PR DESCRIPTION
Builds on top of `add-dotenv` #27  branch.

Adds some basic http logging via [morgan](https://www.npmjs.com/package/morgan).

Feel free to edit or pick a different format, IMO the only high priority items are url, response code and response time. Note it does make a bit of a mess when interleaved with `debug` logs, but better than nothing 🤷‍♂.

```
::ffff:10.200.10.1 - - [27/Jan/2020:18:55:14 +0000] "GET /communities/0x66b8b3ad41C7003BE6d21Bd799bAC967F9A064D4/stats HTTP/1.1" 503 149 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_212)"
::ffff:10.200.10.1 - - [27/Jan/2020:18:55:16 +0000] "GET /communities/0x66b8b3ad41C7003BE6d21Bd799bAC967F9A064D4/stats HTTP/1.1" 503 149 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_212)"
::ffff:10.200.10.1 - - [27/Jan/2020:18:55:18 +0000] "GET /communities/0x66b8b3ad41C7003BE6d21Bd799bAC967F9A064D4/stats HTTP/1.1" 200 287 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_212)"
::ffff:10.200.10.1 - - [27/Jan/2020:18:55:19 +0000] "GET /communities/0x66b8b3ad41C7003BE6d21Bd799bAC967F9A064D4/stats HTTP/1.1" 200 287 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_212)"
::ffff:10.200.10.1 - - [27/Jan/2020:18:55:19 +0000] "GET /communities/0x66b8b3ad41C7003BE6d21Bd799bAC967F9A064D4/members/0x0000000000000000000000000000000000000001 HTTP/1.1" 404 118 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_212)"
::ffff:10.200.10.1 - - [27/Jan/2020:18:55:20 +0000] "GET /communities/0x66b8b3ad41C7003BE6d21Bd799bAC967F9A064D4/members/0x0000000000000000000000000000000000000001 HTTP/1.1" 404 118 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_212)"
```