### PR TITLE
Add a system test to integration test step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         - ETHEREUM_PRIVATE_KEY="0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
       script:
         - .travis_scripts/integration_test.sh
+        - npm run system-tests
       after_failure:
         - docker ps
         - docker logs streamr_dev_cp

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build-contracts": "etherlime --solcVersion=0.4.24 compile",
     "unit-tests": "mocha test/unit --exit",
     "integration-tests": "mocha test/integration --exit",
+    "system-tests": "mocha test/system/engine-and-editor-api.js --exit",
     "contract-tests": "npm run build-contracts && etherlime test --solcVersion=0.4.24 test/contracts",
     "test": "npm run unit-tests && npm run integration-tests && npm run contract-tests"
   },


### PR DESCRIPTION
or should it be separate step?

add the one test that has been run in the CI before splitting system tests to own directory (engine-and-editor-api.js)