### PR TITLE
Pull in monoplasma fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20847,6 +20847,14 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-2.1.0.tgz",
+      "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
+      "requires": {
+        "p-map": "^2.0.0"
+      }
+    },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
@@ -20882,6 +20890,11 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-timeout": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "monoplasma": "0.1.10",
     "morgan": "1.9.1",
     "mz": "2.7.0",
+    "p-all": "2.1.0",
     "streamr-client": "3.0.1"
   },
   "devDependencies": {

--- a/scripts/start_operator.js
+++ b/scripts/start_operator.js
@@ -13,7 +13,7 @@ const { Wallet, Contract, providers: { JsonRpcProvider } } = require("ethers")
 
 const CommunityProductJson = require("../build/CommunityProduct.json")
 
-const FileStore = require("monoplasma/src/fileStore")
+const FileStore = require("../src/fileStore")
 const Operator = require("../src/operator")
 const { throwIfSetButNotContract /*, throwIfNotSet */ } = require("../src/utils/checkArguments")
 const deployCommunity = require("../src/utils/deployCommunity")

--- a/scripts/watch_community.js
+++ b/scripts/watch_community.js
@@ -15,7 +15,7 @@ const {
 
 const CommunityProductJson = require("../build/CommunityProduct.json")
 
-const FileStore = require("monoplasma/src/fileStore")
+const FileStore = require("../src/fileStore")
 const MonoplasmaWatcher = require("../src/watcher")
 const { throwIfNotContract } = require("../src/utils/checkArguments")
 

--- a/src/fileStore.js
+++ b/src/fileStore.js
@@ -1,0 +1,184 @@
+const fs = require("mz/fs")
+const path = require("path")
+
+/**
+ * @typedef {Object} OperatorState
+ * @property {string} tokenAddress Ethereum address of token used by Monoplasma
+ */
+/**
+ * @param {String} storeDir where json files are stored
+ */
+module.exports = class FileStore {
+
+    constructor(storeDir, log, maxLogLen) {
+        this.log = log || (() => {})
+        this.maxLogLen = maxLogLen || 840
+
+        this.log(`Setting up fileStore directories under ${storeDir}...`)
+        const blocksDir = path.join(storeDir, "blocks")
+        const eventsDir = path.join(storeDir, "events")
+        fs.mkdirSync(storeDir, { recursive: true })
+        fs.mkdirSync(blocksDir, { recursive: true })
+        fs.mkdirSync(eventsDir, { recursive: true })
+        this.blockNameRE = /(\d*)\.json/
+
+        this.stateStorePath = path.join(storeDir, "state.json")
+        this.getBlockPath = blockNumber => path.join(blocksDir, blockNumber + ".json")
+        this.getEventPath = blockNumber => path.join(eventsDir, blockNumber + ".json")
+        this.getLatestPath = () => path.join(blocksDir, "latest.json")
+    }
+
+
+    sanitize(logEntry) {
+        return logEntry.length < this.maxLogLen ? logEntry : logEntry.slice(0, this.maxLogLen) + "... TOTAL LENGTH: " + logEntry.length
+    }
+
+    /** @returns {OperatorState} Operator state from the file */
+    async loadState() {
+        this.log(`Loading state from ${this.stateStorePath}...`)
+        const raw = await fs.readFile(this.stateStorePath).catch(() => "{}")
+        return JSON.parse(raw)
+    }
+
+    /**
+     * @param {OperatorState} state Operator state to save
+     */
+    async saveState(state) {
+        const raw = JSON.stringify(state)
+        this.log(`Saving state to ${this.stateStorePath}: ${raw.slice(0, 1000)}${raw.length > 1000 ? "... TOTAL LENGTH: " + raw.length : ""}`)
+        return fs.writeFile(this.stateStorePath, raw)
+    }
+
+    /**
+     * @param {number} blockNumber Root-chain block number corresponding to a published side-chain block
+     */
+    async loadBlock(blockNumber) {
+        const path = this.getBlockPath(blockNumber)
+        this.log(`Loading block ${blockNumber} from ${path}...`)
+        const raw = await fs.readFile(path)
+        const memberArray = JSON.parse(raw)
+        return memberArray
+    }
+    async hasLatestBlock() {
+        const path = this.getLatestPath()
+        return fs.exists(path)
+    }
+    async getLatestBlock() {
+        const existing = await this.hasLatestBlock()
+        if(!existing) { return undefined }
+        const path = this.getLatestPath()
+        this.log(`Loading block latest from ${path}...`)
+        const raw = await fs.readFile(path)
+        const memberArray = JSON.parse(raw)
+        return memberArray
+    }
+
+    /**
+     * @param {number} blockNumber Root-chain block number corresponding to a published side-chain block
+     */
+    async blockExists(blockNumber) {
+        const path = this.getBlockPath(blockNumber)
+        return fs.exists(path)
+    }
+
+    /**
+     * @param {number} [maxNumberLatest] of latest blocks to list
+     * @returns {Promise<Array<number>>} block numbers that have been stored
+     */
+    async listBlockNumbers(maxNumberLatest) {
+        const fileList = await fs.readdir(this.blocksDir)
+        let blockNumbers = fileList
+            .map(fname => fname.match(this.blockNameRE))
+            .filter(x => x)
+            .map(match => +match[1])
+        blockNumbers.sort((a, b) => a - b)  // sort as numbers, just sort() converts to strings first
+        if (maxNumberLatest) {
+            blockNumbers = blockNumbers.slice(-maxNumberLatest)
+        }
+        return blockNumbers
+    }
+
+    /**
+     * @typedef {Object} Block Monoplasma side-chain block, see monoplasma.js:storeBlock
+     * @property {number} blockNumber Root-chain block number corresponding to a published side-chain block
+     * @property {Array<Object>} members MonoplasmaMember.toObject()s with their earnings etc.
+     * @property {number} timestamp seconds since epoch, similar to Ethereum block.timestamp
+     * @property {number} totalEarnings sum of members.earnings, to avoid re-calculating it (often needed)
+     */
+    /**
+     * @param {Block} block to be stored, called from monoplasma.js:storeBlock
+     */
+    async saveBlock(block) {
+        if (!block || !block.blockNumber) { throw new Error(`Bad block: ${JSON.stringify(block)}`) }
+        const path = this.getBlockPath(block.blockNumber)
+        const raw = JSON.stringify(block)
+        this.log(`Saving block ${block.blockNumber} to ${path}: ${this.sanitize(raw)}`)
+        if (await fs.exists(path)) { console.error(`Overwriting block ${block.blockNumber}!`) }
+        return fs.writeFile(path, raw,(err) => {
+            if (err) throw err;
+            this.makeLatestSymlink(block.blockNumber)
+          })
+    }
+
+    async makeLatestSymlink(blockNum){
+        const path = this.getBlockPath(blockNum)
+        const latest = this.getLatestPath()
+        const exists = await fs.exists(latest)
+        console.log(`making symlink ${latest} to ${path} ${exists}`)
+        if (exists) { 
+            const latestBlock  = await this.getLatestBlock()
+            //only link if block is newer
+            console.log(`NM symlink ${latestBlock.blockNumber} to ${blockNum}`)
+            if(latestBlock.blockNumber > blockNum) {return}
+            fs.unlinkSync(latest)
+        }
+        //create latest.json link
+        fs.symlink(path, latest)
+    }
+
+    /**
+     * @typedef {Object} Event join/part events are stored in file for playback, others come from Ethereum
+     * @property {number} blockNumber Root-chain block number after which events happened
+     * @property {number} transactionIndex index within block, for join/part it should just be large
+     * @property {string} event "Join" or "Part" (TODO: could jsdoc enums handle this?)
+     * @property {Array<string>} addressList
+     */
+    /**
+     * @param {number} blockNumber Root-chain block number after which events happened
+     * @param {Array<Event>} events to be associated with blockNumber
+     */
+    async saveEvents(blockNumber, events) {
+        events = Array.isArray(events) ? events : [events]
+        if (events.length < 1) {
+            this.log(`Empty events given for block #${blockNumber}, not saving`)
+            return
+        }
+        const path = this.getEventPath(blockNumber)
+        const rawOld = await fs.readFile(path).catch(() => "[]")
+        const oldEvents = JSON.parse(rawOld)
+        this.log(`Saving ${events.length} event(s like) ${this.sanitize(JSON.stringify(events[0]))} to ${path} (appending after ${oldEvents.length} old events in this block)`)
+        const newEvents = oldEvents.concat(events)
+        const raw = JSON.stringify(newEvents)
+        return fs.writeFile(path, raw)
+    }
+
+    /**
+     * @param {number} fromBlock Sidechain block to load
+     * @param {number} [toBlock=fromBlock+1] load blocks until toBlock, INCLUSIVE (just like getPastEvents)
+     * @returns {Array<Event>} of events, if blocks found, otherwise []
+     */
+    async loadEvents(fromBlock, toBlock) {
+        let ret = []
+        const to = toBlock || fromBlock
+        for (let bnum = fromBlock; bnum <= to; bnum++) {
+            const path = this.getEventPath(bnum)
+            if (await fs.exists(path)) {
+                this.log(`Loading events from ${path}`)
+                const raw = await fs.readFile(path).catch(() => "[]")
+                const eventList = JSON.parse(raw)
+                ret = ret.concat(eventList)
+            }
+        }
+        return ret
+    }
+}

--- a/src/fileStore.js
+++ b/src/fileStore.js
@@ -59,10 +59,12 @@ module.exports = class FileStore {
         const memberArray = JSON.parse(raw)
         return memberArray
     }
+
     async hasLatestBlock() {
         const path = this.getLatestPath()
         return fs.exists(path)
     }
+
     async getLatestBlock() {
         const existing = await this.hasLatestBlock()
         if (!existing) { return undefined }

--- a/src/fileStore.js
+++ b/src/fileStore.js
@@ -118,10 +118,8 @@ module.exports = class FileStore {
         if (await fs.exists(path)) {
             this.log(`Overwriting block ${block.blockNumber}!`)
         }
-        return fs.writeFile(path, raw, (err) => {
-            if (err) throw err
-            return this.makeLatestSymlink(block.blockNumber)
-        })
+        await fs.writeFile(path, raw)
+        return this.makeLatestSymlink(block.blockNumber)
     }
 
     async makeLatestSymlink(blockNum){

--- a/src/fileStore.js
+++ b/src/fileStore.js
@@ -114,30 +114,30 @@ module.exports = class FileStore {
         if (!block || !block.blockNumber) { throw new Error(`Bad block: ${JSON.stringify(block)}`) }
         const path = this.getBlockPath(block.blockNumber)
         const raw = JSON.stringify(block)
-        this.log(`Saving block ${block.blockNumber} to ${path}: ${this.sanitize(raw)}`)
+        this.log(`Saving block ${block.blockNumber} to ${path}`)
         if (await fs.exists(path)) {
             this.log(`Overwriting block ${block.blockNumber}!`)
         }
-        return fs.writeFile(path, raw,(err) => {
+        return fs.writeFile(path, raw, (err) => {
             if (err) throw err
-            this.makeLatestSymlink(block.blockNumber)
+            return this.makeLatestSymlink(block.blockNumber)
         })
     }
 
     async makeLatestSymlink(blockNum){
         const path = this.getBlockPath(blockNum)
         const latest = this.getLatestPath()
-        const exists = await fs.exists(latest)
-        this.log(`making symlink ${latest} to ${path} ${exists}`)
+        const exists = fs.existsSync(latest)
         if (exists) {
-            const latestBlock  = await this.getLatestBlock()
-            //only link if block is newer
+            const latestBlock = await this.getLatestBlock()
+            // only link if block is newer
             this.log(`NM symlink ${latestBlock.blockNumber} to ${blockNum}`)
-            if (latestBlock.blockNumber > blockNum) {return}
+            if (latestBlock.blockNumber > blockNum) { return }
             fs.unlinkSync(latest)
         }
+        this.log(`making symlink ${latest} to ${path} ${exists}`)
         //create latest.json link
-        fs.symlink(path, latest)
+        fs.symlinkSync(path, latest)
     }
 
     /**

--- a/src/fileStore.js
+++ b/src/fileStore.js
@@ -65,7 +65,7 @@ module.exports = class FileStore {
     }
     async getLatestBlock() {
         const existing = await this.hasLatestBlock()
-        if(!existing) { return undefined }
+        if (!existing) { return undefined }
         const path = this.getLatestPath()
         this.log(`Loading block latest from ${path}...`)
         const raw = await fs.readFile(path)
@@ -113,23 +113,25 @@ module.exports = class FileStore {
         const path = this.getBlockPath(block.blockNumber)
         const raw = JSON.stringify(block)
         this.log(`Saving block ${block.blockNumber} to ${path}: ${this.sanitize(raw)}`)
-        if (await fs.exists(path)) { console.error(`Overwriting block ${block.blockNumber}!`) }
+        if (await fs.exists(path)) {
+            this.log(`Overwriting block ${block.blockNumber}!`)
+        }
         return fs.writeFile(path, raw,(err) => {
-            if (err) throw err;
+            if (err) throw err
             this.makeLatestSymlink(block.blockNumber)
-          })
+        })
     }
 
     async makeLatestSymlink(blockNum){
         const path = this.getBlockPath(blockNum)
         const latest = this.getLatestPath()
         const exists = await fs.exists(latest)
-        console.log(`making symlink ${latest} to ${path} ${exists}`)
-        if (exists) { 
+        this.log(`making symlink ${latest} to ${path} ${exists}`)
+        if (exists) {
             const latestBlock  = await this.getLatestBlock()
             //only link if block is newer
-            console.log(`NM symlink ${latestBlock.blockNumber} to ${blockNum}`)
-            if(latestBlock.blockNumber > blockNum) {return}
+            this.log(`NM symlink ${latestBlock.blockNumber} to ${blockNum}`)
+            if (latestBlock.blockNumber > blockNum) {return}
             fs.unlinkSync(latest)
         }
         //create latest.json link

--- a/src/member.js
+++ b/src/member.js
@@ -7,7 +7,6 @@ module.exports = class MonoplasmaMember {
         this.address = MonoplasmaMember.validateAddress(address)
         this.earnings = earnings ? new BN(earnings) : new BN(0)
         this.active = active
-        console.log(`active ${active} ${this.active}`)
     }
 
     getEarningsAsString() {

--- a/src/member.js
+++ b/src/member.js
@@ -2,11 +2,11 @@ const BN = require("bn.js")
 const {utils: { isAddress }} = require("web3")
 
 module.exports = class MonoplasmaMember {
-    constructor(name, address, earnings) {
+    constructor(name, address, earnings, active) {
         this.name = name || ""
         this.address = MonoplasmaMember.validateAddress(address)
         this.earnings = earnings ? new BN(earnings) : new BN(0)
-        this.active = true
+        this.active = active || true
     }
 
     getEarningsAsString() {
@@ -36,6 +36,7 @@ module.exports = class MonoplasmaMember {
         const obj = {
             address: this.address,
             earnings: this.earnings.toString(10),
+            active: this.active
         }
         if (this.name) {
             obj.name = this.name
@@ -44,7 +45,7 @@ module.exports = class MonoplasmaMember {
     }
 
     static fromObject(obj) {
-        return new MonoplasmaMember(obj.name, obj.address, obj.earnings)
+        return new MonoplasmaMember(obj.name, obj.address, obj.earnings, obj.active)
     }
 
     /** Produces a hashable string representation in hex form (starts with "0x") */

--- a/src/member.js
+++ b/src/member.js
@@ -6,7 +6,7 @@ module.exports = class MonoplasmaMember {
         this.name = name || ""
         this.address = MonoplasmaMember.validateAddress(address)
         this.earnings = earnings ? new BN(earnings) : new BN(0)
-        this.active = active
+        this.active = !!active
     }
 
     getEarningsAsString() {
@@ -22,21 +22,21 @@ module.exports = class MonoplasmaMember {
     }
 
     isActive() {
-        return this.active
+        return !!this.active
     }
 
     /**
      * @param {boolean} activeState true if active, false if not going to be getting revenues
      */
     setActive(activeState) {
-        this.active = activeState
+        this.active = !!activeState
     }
 
     toObject() {
         const obj = {
             address: this.address,
             earnings: this.earnings.toString(10),
-            active: this.active
+            active: !!this.active
         }
         if (this.name) {
             obj.name = this.name

--- a/src/member.js
+++ b/src/member.js
@@ -1,0 +1,74 @@
+const BN = require("bn.js")
+const {utils: { isAddress }} = require("web3")
+
+module.exports = class MonoplasmaMember {
+    constructor(name, address, earnings) {
+        this.name = name || ""
+        this.address = MonoplasmaMember.validateAddress(address)
+        this.earnings = earnings ? new BN(earnings) : new BN(0)
+        this.active = true
+    }
+
+    getEarningsAsString() {
+        return this.earnings.toString(10)
+    }
+
+    getEarningsAsInt() {
+        return this.earnings.toNumber()
+    }
+
+    addRevenue(amount) {
+        this.earnings = this.earnings.add(new BN(amount))
+    }
+
+    isActive() {
+        return this.active
+    }
+
+    /**
+     * @param {boolean} activeState true if active, false if not going to be getting revenues
+     */
+    setActive(activeState) {
+        this.active = activeState
+    }
+
+    toObject() {
+        const obj = {
+            address: this.address,
+            earnings: this.earnings.toString(10),
+        }
+        if (this.name) {
+            obj.name = this.name
+        }
+        return obj
+    }
+
+    static fromObject(obj) {
+        return new MonoplasmaMember(obj.name, obj.address, obj.earnings)
+    }
+
+    /** Produces a hashable string representation in hex form (starts with "0x") */
+    // TODO: move to merkletree.js:hashLeaf
+    toHashableString() {
+        return this.address + this.earnings.toString(16, 64)
+    }
+
+    getProof(tree) {
+        return this.earnings.gt(new BN(0)) ? tree.getPath(this.address) : []
+    }
+
+    static getHashableString(address, earnings) {
+        return address + earnings.toString(16, 64)
+    }
+
+    static validateAddress(address) {
+        let extended = address
+        if (address.length === 40) {
+            extended = `0x${address}`
+        }
+        if (!isAddress(extended)) {
+            throw new Error(`Bad Ethereum address: ${address}`)
+        }
+        return extended
+    }
+}

--- a/src/member.js
+++ b/src/member.js
@@ -2,11 +2,12 @@ const BN = require("bn.js")
 const {utils: { isAddress }} = require("web3")
 
 module.exports = class MonoplasmaMember {
-    constructor(name, address, earnings, active) {
+    constructor(name, address, earnings, active = true) {
         this.name = name || ""
         this.address = MonoplasmaMember.validateAddress(address)
         this.earnings = earnings ? new BN(earnings) : new BN(0)
-        this.active = active || true
+        this.active = active
+        console.log(`active ${active} ${this.active}`)
     }
 
     getEarningsAsString() {

--- a/src/operator.js
+++ b/src/operator.js
@@ -4,7 +4,7 @@ const sleep = require("./utils/sleep-promise")
 const { throwIfBadAddress } = require("./utils/checkArguments")
 
 const MonoplasmaWatcher = require("./watcher")
-const MonoplasmaState = require("monoplasma/src/state")
+const MonoplasmaState = require("./state")
 
 const MonoplasmaJson = require("../build/Monoplasma.json")
 

--- a/src/operator.js
+++ b/src/operator.js
@@ -61,8 +61,9 @@ module.exports = class MonoplasmaOperator {
 
     async lastPublishedBlock(){
         const lb = await this.watcher.plasma.store.getLatestBlock()
-        if(lb == undefined) 
+        if (lb == undefined) {
             return undefined
+        }
         return lb.blockNumber
     }
 

--- a/src/operator.js
+++ b/src/operator.js
@@ -32,7 +32,7 @@ module.exports = class MonoplasmaOperator {
         //this.tokensNotCommitted = 0    // TODO: bignumber
 
         await this.watcher.start(config)
-        this.lastPublishedBlock = (this.watcher.state.lastPublishedBlock && this.watcher.state.lastPublishedBlock.blockNumber) || 0
+        //this.lastPublishedBlock = (this.watcher.state.lastPublishedBlock && this.watcher.state.lastPublishedBlock.blockNumber) || 0
 
         // TODO https://streamr.atlassian.net/browse/CPS-82 finalPlasmaStore should be instead just this.watcher.plasma.store
         const finalPlasmaStore = {
@@ -59,14 +59,22 @@ module.exports = class MonoplasmaOperator {
         await this.watcher.stop()
     }
 
+    async lastPublishedBlock(){
+        const lb = await this.watcher.plasma.store.getLatestBlock()
+        if(lb == undefined) 
+            return undefined
+        return lb.blockNumber
+    }
+
     // TODO: block publishing should be based on value-at-risk, that is, publish after so-and-so many tokens received
     // see https://streamr.atlassian.net/browse/CPS-39
     async onTokensReceived(event) {
+        const last = await this.lastPublishedBlock()
         const blockNumber = event.blockNumber
-        if (+blockNumber >= +this.lastPublishedBlock + +this.minIntervalBlocks) {
+        if (last == undefined || +blockNumber >= last + +this.minIntervalBlocks) {
             await this.publishBlock(blockNumber)
         } else {
-            this.log(`Skipped publishing at ${blockNumber}, last publish at ${this.lastPublishedBlock} (this.minIntervalBlocks = ${this.minIntervalBlocks})`)
+            this.log(`Skipped publishing at ${blockNumber}, last publish at ${last} (this.minIntervalBlocks = ${this.minIntervalBlocks})`)
         }
     }
 
@@ -83,9 +91,8 @@ module.exports = class MonoplasmaOperator {
 
         await sleep(0)          // ensure lastObservedBlockNumber is updated since this likely happens as a response to event
         const blockNumber = rootchainBlockNumber || this.watcher.state.lastObservedBlockNumber
-        if (blockNumber <= this.lastPublishedBlock) { throw new Error(`Block #${this.lastPublishedBlock} has already been published, can't publish #${blockNumber}`) }
-        this.lastPublishedBlock = blockNumber
-
+        if (blockNumber <= await this.lastPublishedBlock()) { throw new Error(`Block #${this.lastPublishedBlock} has already been published, can't publish #${blockNumber}`) }
+            
         // see https://streamr.atlassian.net/browse/CPS-20
         // TODO: separate finalPlasma currently is so much out of sync with watcher.plasma that proofs turn out wrong
         //       perhaps communitiesRouter should get the proofs from operator's finalPlasma?
@@ -100,11 +107,14 @@ module.exports = class MonoplasmaOperator {
         const ipfsHash = ""     // TODO: upload this.finalPlasma to IPFS while waiting for finality
 
         const tx = await this.contract.commit(blockNumber, hash, ipfsHash)
-
+        const tr = await tx.wait(1)        // confirmations
+        
         // TODO https://streamr.atlassian.net/browse/CPS-82 should be instead:
         // await this.finalPlasma.storeBlock(blockNumber) // TODO: give a timestamp
+        // this.watcher.state.lastPublishedBlock = {blockNumber: blockNumber}
         await this.watcher.plasma.storeBlock(blockNumber)
-        const tr = await tx.wait(1)        // confirmations
+        await this.watcher.saveState()
+        
         this.log(`Commit sent, receipt: ${JSON.stringify(tr)}`)
 
         // TODO: something causes events to be replayed many times, resulting in wrong balances. It could have something to do with the state cloning that happens here

--- a/src/server.js
+++ b/src/server.js
@@ -108,9 +108,10 @@ module.exports = class CommunityProductServer {
             this.log(`Event ${num} of ${total} processed in ${Date.now() - startEventTime}ms, ${Math.round((num / total) * 100)}% complete.`)
         }
         this.log(`Finished playback of ${total} operator change events in ${Date.now() - startAllTime}ms.`)
-        if (numErrors && numErrors === total) {
+        const numCommunities = Object.keys(this.communities).length
+        if (numErrors && numErrors === numCommunities) {
             // kill if all operators errored
-            throw new Error(`All ${total} operator changed events failed to process. Shutting down.`)
+            throw new Error(`All ${numCommunities} communities failed to start. Shutting down.`)
         }
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,7 @@ const {
 } = require("ethers")
 
 const debug = require("debug")
-const FileStore = require("monoplasma/src/fileStore")
+const FileStore = require("./fileStore")
 
 const MonoplasmaOperator = require("./operator")
 const StreamrChannel = require("./streamrChannel")

--- a/src/state.js
+++ b/src/state.js
@@ -1,9 +1,9 @@
 const MonoplasmaMember = require("./member")
-const MerkleTree = require("./merkletree")
+const MerkleTree = require("monoplasma/src/merkletree")
 const BN = require("bn.js")
 const toBN = require("number-to-bn")
 const {utils: { toWei }} = require("web3")
-const now = require("./utils/now")
+const now = require("monoplasma/src/utils/now")
 const { throwIfBadAddress } = require("./utils/checkArguments")
 
 /**
@@ -47,7 +47,7 @@ module.exports = class MonoplasmaState {
         this.currentTimestamp = initialTimestamp
 
         /** @property {Array<MonoplasmaMember>} members */
-        this.members = initialMembers.map(m => new MonoplasmaMember(undefined, m.address, m.earnings))
+        this.members = initialMembers.map(m => new MonoplasmaMember(m.name, m.address, m.earnings, m.active))
         /** @property {MerkleTree} tree The MerkleTree for calculating the hashes */
         this.tree = new MerkleTree(this.members)
         /** @property {string}  adminAddress the owner address who receives the admin fee and the default payee if no memebers */
@@ -308,6 +308,7 @@ module.exports = class MonoplasmaState {
             if (!m) { throw new Error(`Bad index ${i}`) }   // TODO: remove in production; this means updating indexOf has been botched
             m.setActive(true)
         }
+        //console.log(`addMember ${i} ${address} ${name} ${isNewAddress}`)
         // tree.update(members)     // no need for update since no revenue allocated
         return isNewAddress
     }

--- a/src/state.js
+++ b/src/state.js
@@ -276,7 +276,7 @@ module.exports = class MonoplasmaState {
         const activeMembers = this.members.filter(m => m.isActive())
         const activeCount = activeMembers.length
         if (activeCount === 0) {
-            console.warn(`No active members in community! Allocating ${amount} to admin account ${this.adminMember.address}`)
+            //console.warn(`No active members in community! Allocating ${amount} to admin account ${this.adminMember.address}`)
             this.adminMember.addRevenue(amount)
         } else {
             const amountBN = new BN(amount)

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,406 @@
+const MonoplasmaMember = require("./member")
+const MerkleTree = require("./merkletree")
+const BN = require("bn.js")
+const toBN = require("number-to-bn")
+const {utils: { toWei }} = require("web3")
+const now = require("./utils/now")
+const { throwIfBadAddress } = require("./utils/checkArguments")
+
+/**
+ * Monoplasma state object
+ *
+ * Contains the logic of revenue distribution as well as current balances of/and participants
+ */
+module.exports = class MonoplasmaState {
+    /**
+     * @param {number} blockFreezeSeconds
+     * @param {Array} initialMembers objects: [ { address, earnings }, { address, earnings }, ... ]
+     * @param {Object} store offering persistance for blocks
+     * @param {string} adminAddress where revenues go if there are no members
+     * @param {Object} adminFeeFraction fraction of revenue that goes to admin. Can be expressed as: number between 0 and 1, string of wei, BN of Wei (1 = 10^18)
+     * @param {Number} initialBlockNumber after which the state is described by this object
+     * @param {Number} initialTimestamp after which the state is described by this object
+     */
+    constructor(blockFreezeSeconds, initialMembers, store, adminAddress, adminFeeFraction, initialBlockNumber = 0, initialTimestamp = 0) {
+        throwIfBadAddress(adminAddress, "MonoplasmaState argument adminAddress")
+        if (!Array.isArray(initialMembers)) {
+            initialMembers = []
+        }
+        /** @property {fileStore} store persistence for published blocks */
+        this.store = store
+        /** @property {number} blockFreezeSeconds after which blocks become withdrawable */
+        this.blockFreezeSeconds = blockFreezeSeconds
+        /** @property {number} totalEarnings by all members together; should equal balanceOf(contract) + contract.totalWithdrawn */
+        this.totalEarnings = initialMembers.reduce((sum, m) => sum.iadd(new BN(m.earnings)), new BN(0))
+
+        /** @property {Array<Block>} latestBlocks that have been stored. Kept to figure out  */
+        this.latestBlocks = []
+
+        // TODO: consider something like https://www.npmjs.com/package/lru-cache instead; it seems a bit complicated (length function) but could be good for limiting memory use
+        /** @property {Array<Object<number, MerkleTree>>} treeCache LRU cache of (blockNumber, cacheHitCount, tree) */
+        this.treeCache = []
+        this.treeCacheSize = 5  // TODO: make tuneable? Must be at least 2
+
+        /** @property {Number} currentBlock that was last processed. State described by this object is after that block and all its transactions. */
+        this.currentBlock = initialBlockNumber
+        /** @property {Number} currentTimestamp that was last processed. State described by this object is at or after that time. */
+        this.currentTimestamp = initialTimestamp
+
+        /** @property {Array<MonoplasmaMember>} members */
+        this.members = initialMembers.map(m => new MonoplasmaMember(undefined, m.address, m.earnings))
+        /** @property {MerkleTree} tree The MerkleTree for calculating the hashes */
+        this.tree = new MerkleTree(this.members)
+        /** @property {string}  adminAddress the owner address who receives the admin fee and the default payee if no memebers */
+        this.adminAddress = adminAddress
+        /** @property {BN}  adminFeeFraction fraction of revenue that goes to admin */
+        this.setAdminFeeFraction(adminFeeFraction || 0)
+
+        this.indexOf = {}
+        this.members.forEach((m, i) => { this.indexOf[m.address] = i })
+
+        const wasNew = this.addMember(adminAddress, "admin")
+        const i = this.indexOf[adminAddress]
+        this.adminMember = this.members[i]
+
+        // don't enable adminMember to participate into profit-sharing (unless it was also in initialMembers)
+        if (wasNew) {
+            this.adminMember.setActive(false)
+        }
+    }
+
+    clone(storeOverride) {
+        return new MonoplasmaState(
+            this.blockFreezeSeconds,
+            this.members,
+            storeOverride || this.store,
+            this.adminAddress,
+            this.adminFeeFraction,
+        )
+    }
+
+    // ///////////////////////////////////
+    //      MEMBER API
+    // ///////////////////////////////////
+
+    getMembers() {
+        return this.members
+            .filter(m => m.isActive())
+            .map(m => m.toObject())
+    }
+
+    getMemberCount() {
+        // "admin member" shouldn't show up in member count unless separately added
+        const total = this.members.length - (this.adminMember.isActive() ? 0 : 1)
+        const active = this.members.filter(m => m.isActive()).length
+        return {
+            total,
+            active,
+            inactive: total - active,
+        }
+    }
+
+    getTotalRevenue() {
+        return this.totalEarnings.toString(10)
+    }
+
+    getLatestBlock() {
+        if (this.latestBlocks.length < 1) { return null }
+        const block = this.latestBlocks[0]
+        return block
+    }
+
+    getLatestWithdrawableBlock() {
+        if (this.latestBlocks.length < 1) { return null }
+        const nowTimestamp = now()
+        const i = this.latestBlocks.findIndex(b => nowTimestamp - b.timestamp > this.blockFreezeSeconds, this)
+        if (i === -1) { return null }         // all blocks still frozen
+        this.latestBlocks.length = i + 1    // throw away older than latest withdrawable
+        const block = this.latestBlocks[i]
+        return block
+    }
+
+    /**
+     * Retrieve snapshot written in {this.storeBlock}
+     * @param {number} blockNumber
+     */
+    async getBlock(blockNumber) {
+        const cachedBlock = this.latestBlocks.find(b => b.blockNumber === blockNumber)
+        if (cachedBlock) {
+            return cachedBlock
+        }
+        // TODO: add LRU cache of old blocks?
+        if (!await this.store.blockExists(blockNumber)) { throw new Error(`Block #${blockNumber} not found in published blocks`) }
+        const block = await this.store.loadBlock(blockNumber)
+        return block
+    }
+
+    async listBlockNumbers(maxNumberLatest) {
+        return this.store.listBlockNumbers(maxNumberLatest)
+    }
+
+    /**
+     * Get member's current status (without valid withdrawal proof because it hasn't been recorded)
+     * @param {string} address
+     */
+    getMember(address) {
+        const i = this.indexOf[address]
+        if (i === undefined) { return null }
+        const m = this.members[i]
+        if (!m) { throw new Error(`Bad index ${i}`) }   // TODO: change to return null in production
+        const obj = m.toObject()
+        obj.active = m.isActive()
+        obj.proof = this.getProof(address)
+        return obj
+    }
+
+    /**
+     * Get member's info with withdrawal proof at given block
+     * @param {string} address
+     * @param {number} blockNumber at which (published) block
+     */
+    async getMemberAt(address, blockNumber) {
+        const block = await this.getBlock(blockNumber)
+        const member = block.members.find(m => m.address === address)   // TODO: DANGER: O(n^2) potential here! If members were sorted (or indexOF retained), this would be faster
+        if (!member) {
+            throw new Error(`Member ${address} not found in block ${blockNumber}`)
+        }
+        const members = block.members.map(m => MonoplasmaMember.fromObject(m))
+        const tree = new MerkleTree(members)
+        member.proof = tree.getPath(address)
+        return member
+    }
+
+    /**
+     * Cache recently asked blocks' MerkleTrees
+     * NOTE: this function is potentially CPU heavy (lots of members)
+     *       Also, it's on "heavy load path" for Monoplasma API server
+     *         because members will probably query for their balances often
+     *         and proofs are generated at the same (because why not)
+     */
+    async getTreeAt(blockNumber) {
+        if (!blockNumber && blockNumber !== 0) { throw new Error("Must give blockNumber") }
+        let cached = this.treeCache.find(c => c.blockNumber === blockNumber)
+        if (!cached) {
+            // evict the least used if cache is full
+            if (this.treeCache.length >= this.treeCacheSize) {
+                let minIndex = -1
+                let minHits = Number.MAX_SAFE_INTEGER
+                this.treeCache.forEach((c, i) => {
+                    if (c.hitCount < minHits) {
+                        minHits = c.hitCount
+                        minIndex = i
+                    }
+                })
+                this.treeCache.splice(minIndex, 1)  // delete 1 item at minIndex
+            }
+
+            const block = await this.getBlock(blockNumber)
+            const members = block.members.map(m => MonoplasmaMember.fromObject(m))
+            const tree = new MerkleTree(members)
+            cached = {
+                blockNumber,
+                tree,
+                hitCount: 0,
+            }
+            this.treeCache.push(cached)
+        }
+        cached.hitCount += 1
+        return cached.tree
+    }
+
+    /**
+     * Get hypothetical proof of earnings from current status
+     * @param {string} address with earnings to be verified
+     * @returns {Array|null} of bytes32 hashes ["0x123...", "0xabc..."], or null if address not found
+     */
+    getProof(address) {
+        return this.tree.includes(address) ? this.tree.getPath(address) : null
+    }
+
+    /**
+     * Get proof of earnings for withdrawal ("payslip") from specific (published) block
+     * @param {string} address with earnings to be verified
+     * @param {number} blockNumber at which (published) block
+     * @returns {Array} of bytes32 hashes ["0x123...", "0xabc..."]
+     */
+    async getProofAt(address, blockNumber) {
+        const block = await this.getBlock(blockNumber)
+        const member = block.members.find(m => m.address === address)   // TODO: DANGER: O(n^2) potential here! If members were sorted (or indexOF retained), this would be faster
+        if (!member) {
+            throw new Error(`Member ${address} not found in block ${blockNumber}`)
+        }
+        const tree = await this.getTreeAt(blockNumber)
+        const path = tree.getPath(address)
+        return path
+    }
+
+    getRootHash() {
+        return this.tree.getRootHash()
+    }
+
+    async getRootHashAt(blockNumber) {
+        if (!this.store.blockExists(blockNumber)) { throw new Error(`Block #${blockNumber} not found in published blocks`) }
+        const tree = await this.getTreeAt(blockNumber)
+        const rootHash = tree.getRootHash()
+        return rootHash
+    }
+
+    // ///////////////////////////////////
+    //      ADMIN API
+    // ///////////////////////////////////
+
+    /**
+     * @param {Number|String|BN} adminFeeFraction fraction of revenue that goes to admin (string should be scaled by 10**18, like ether)
+     */
+    setAdminFeeFraction(adminFeeFraction) {
+        // convert to BN
+        if (typeof adminFeeFraction === "number") {
+            adminFeeFraction = toBN(toWei(adminFeeFraction.toString(10)))
+        } else if (typeof adminFeeFraction === "string" && adminFeeFraction.length > 0) {
+            adminFeeFraction = toBN(adminFeeFraction)
+        } else if (!adminFeeFraction || adminFeeFraction.constructor.name !== "BN") {
+            throw new Error("setAdminFeeFraction: expecting a number, a string, or a bn.js bignumber, got " + JSON.stringify(adminFeeFraction))
+        }
+
+        if (adminFeeFraction.ltn(0) || adminFeeFraction.gt(toBN(toWei("1")))) {
+            throw Error("setAdminFeeFraction: adminFeeFraction must be between 0 and 1")
+        }
+        //console.log(`Setting adminFeeFraction = ${adminFeeFraction}`)
+        this.adminFeeFraction = adminFeeFraction
+    }
+
+    /**
+     * @param {number} amount of tokens that was added to the Community revenues
+     */
+    addRevenue(amount) {
+        const activeMembers = this.members.filter(m => m.isActive())
+        const activeCount = activeMembers.length
+        if (activeCount === 0) {
+            console.warn(`No active members in community! Allocating ${amount} to admin account ${this.adminMember.address}`)
+            this.adminMember.addRevenue(amount)
+        } else {
+            const amountBN = new BN(amount)
+            const adminFeeBN = amountBN.mul(this.adminFeeFraction).div(new BN(toWei("1", "ether")))
+            //console.log("received tokens amount: "+amountBN + " adminFee: "+adminFeeBN +" fraction * 10^18: "+this.adminFeeFraction)
+            const share = amountBN.sub(adminFeeBN).divn(activeCount)    // TODO: remainder to admin too, let's not waste them!
+            this.adminMember.addRevenue(adminFeeBN)
+            activeMembers.forEach(m => m.addRevenue(share))
+            this.totalEarnings.iadd(amountBN)
+        }
+        this.tree.update(this.members)
+    }
+
+    /**
+     * Add an active recipient into Community, or re-activate existing one (previously removed)
+     * @param {string} address of the new member
+     * @param {string} name of the new member
+     * @returns {boolean} if the added member was new (previously unseen)
+     */
+    addMember(address, name) {
+        const i = this.indexOf[address]
+        const isNewAddress = i === undefined
+        if (isNewAddress) {
+            const m = new MonoplasmaMember(name, address)
+            const newI = this.members.push(m) - 1
+            this.indexOf[address] = newI
+        } else {
+            const m = this.members[i]
+            if (!m) { throw new Error(`Bad index ${i}`) }   // TODO: remove in production; this means updating indexOf has been botched
+            m.setActive(true)
+        }
+        // tree.update(members)     // no need for update since no revenue allocated
+        return isNewAddress
+    }
+
+    /**
+     * De-activate a member, it will not receive revenues until re-activated
+     * @param {string} address
+     * @returns {boolean} if the de-activated member was previously active (and existing)
+     */
+    removeMember(address) {
+        let wasActive = false
+        const i = this.indexOf[address]
+        if (i !== undefined) {
+            const m = this.members[i]
+            if (!m) { throw new Error(`Bad index ${i}`) }   // TODO: remove in production; this means updating indexOf has been botched
+            wasActive = m.isActive()
+            m.setActive(false)
+        }
+        // tree.update(members)     // no need for update since no revenue allocated
+        return wasActive
+    }
+
+    /**
+     * Monoplasma member to be added
+     * @typedef {Object<string, string>} IncomingMember
+     * @property {string} address Ethereum address of the Community member
+     * @property {string} name Human-readable string representation
+     */
+    /**
+     * Add active recipients into Community, or re-activate existing ones (previously removed)
+     * @param {Array<IncomingMember|string>} members
+     * @returns {Array<IncomingMember|string>} members that were actually added
+     */
+    addMembers(members) {
+        const added = []
+        members.forEach(member => {
+            const m = typeof member === "string" ? { address: member } : member
+            const wasNew = this.addMember(m.address, m.name)
+            if (wasNew) { added.push(member) }
+        })
+        return added
+    }
+
+    /**
+     * De-activate members: they will not receive revenues until re-activated
+     * @param {Array<string>} addresses
+     * @returns {Array<string>} addresses of members that were actually removed
+     */
+    removeMembers(addresses) {
+        const removed = []
+        addresses.forEach(address => {
+            const wasActive = this.removeMember(address)
+            if (wasActive) { removed.push(address) }
+        })
+        return removed
+    }
+
+    /**
+     * Snapshot the Monoplasma state for later use (getMemberAt, getProofAt)
+     * @param {number} blockNumber root-chain block number after which this block state is valid
+     */
+    async storeBlock(blockNumber, timestamp) {
+        if (!Number.isInteger(blockNumber) || !(blockNumber > 0)) { throw new Error("blockNumber must be a positive integer")}
+        const latestBlock = {
+            blockNumber,
+            members: this.members.map(m => m.toObject()),
+            timestamp: timestamp || "",
+            storeTimestamp: now(),
+            totalEarnings: this.getTotalRevenue(),
+            owner: this.adminAddress,
+            adminFeeFractionWeiString: this.adminFeeFraction.toString(10),
+        }
+        this.latestBlocks.unshift(latestBlock)  // = insert to beginning
+        await this.store.saveBlock(latestBlock)
+        return latestBlock
+    }
+
+    /**
+     * Return a read-only "member API" that can only query this object
+     */
+    getMemberApi() {
+        return {
+            getMembers: this.getMembers.bind(this),
+            getMember: this.getMember.bind(this),
+            getMemberCount: this.getMemberCount.bind(this),
+            getTotalRevenue: this.getTotalRevenue.bind(this),
+            getProof: this.getProof.bind(this),
+            getProofAt: this.getProofAt.bind(this),
+            getRootHash: this.getRootHash.bind(this),
+            getBlock: this.getBlock.bind(this),
+            getLatestBlock: this.getLatestBlock.bind(this),
+            getLatestWithdrawableBlock: this.getLatestWithdrawableBlock.bind(this),
+            listBlockNumbers: this.listBlockNumbers.bind(this),
+        }
+    }
+}

--- a/src/validator.js
+++ b/src/validator.js
@@ -45,7 +45,7 @@ module.exports = class MonoplasmaValidator {
 
         // update the "validated" version to the block number whose hash was published
         await this.watcher.playbackUntilBlock(blockNumber, this.validatedPlasma)
-        this.watcher.channelPruneCache()    // TODO: should prune only up to this.validatedPlasma.currentTimestamp
+        this.watcher.channelPruneCache()
         this.lastCheckedBlock = blockNumber
 
         // check that the hash at that point in history matches

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -98,17 +98,18 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
             this.log(`Loaded ${Object.keys(this.blockTimestampCache).length} block timestamps from disk`)
         }
 
-        this.eth.on("block", blockNumber => {
-            if (blockNumber % 10 === 0) { this.log(`Block ${blockNumber} observed`) }
-            this.state.lastObservedBlockNumber = blockNumber
-        })
-
-        // this.state should be broken up into state.js, and rest called this.config
         this.log("Initializing Monoplasma state...")
         const savedState = config.reset ? {} : await this.store.loadState()
         this.state = Object.assign({
             adminFee: 0,
         }, savedState, config)
+
+
+        this.eth.on("block", blockNumber => {
+            if (blockNumber % 10 === 0) { this.log(`Block ${blockNumber} observed`) }
+            this.state.lastObservedBlockNumber = blockNumber
+        })
+
 
         // get initial state from contracts, also works as a sanity check for the config
         this.contract = new Contract(this.state.contractAddress, MonoplasmaJson.abi, this.eth)
@@ -123,12 +124,13 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
         this.blockCreateFilter = this.contract.filters.BlockCreated()
         this.tokenTransferFilter = this.token.filters.Transfer(null, this.contract.address)
 
-        let lastPublishedBlockNumber = this.state.lastPublishedBlock && this.state.lastPublishedBlock.blockNumber
+//        let lastPublishedBlockNumber = this.state.lastPublishedBlock && this.state.lastPublishedBlock.blockNumber
         let lastBlock = {
             members: [],
             blockNumber: 0,
             timestamp: 0,
         }
+        /*
         if (lastPublishedBlockNumber) {
             // quick fix for BigNumbers that have ended up in the store.json:
             //   they get serialized as {"_hex":"0x863a0a"}
@@ -138,8 +140,10 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
             this.log(`Reading from store lastPublishedBlockNumber ${lastPublishedBlockNumber}`)
             lastBlock = await this.store.loadBlock(lastPublishedBlockNumber)
         }
-
-        // TODO: this.plasma should be called this.realtimeState
+        */
+       if(await this.store.hasLatestBlock()){
+           lastBlock = await this.store.getLatestBlock()
+       }
         this.log(`Starting from block ${lastBlock.blockNumber} (t=${lastBlock.timestamp}, ${new Date((lastBlock.timestamp || 0) * 1000).toISOString()}) with ${lastBlock.members.length} members`)
         this.plasma = new MonoplasmaState(this.state.blockFreezeSeconds, lastBlock.members, this.store, this.state.adminAddress, this.state.adminFee, lastBlock.blockNumber, lastBlock.timestamp)
 
@@ -182,7 +186,7 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
         })
         this.contract.on(this.blockCreateFilter, (blockNumber, rootHash, ipfsHash, event) => {
             this.log(`Observed creation of block ${+blockNumber} at block ${event.blockNumber} (root ${rootHash}, ipfs "${ipfsHash}")`)
-            this.state.lastPublishedBlock = event.args
+            //this.state.lastPublishedBlock = event.args
             this.emit("blockCreated", event)
         })
         this.token.on(this.tokenTransferFilter, async (to, from, amount, event) => {
@@ -208,7 +212,10 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
         */
 
         // TODO: maybe state saving function should create the state object instead of continuously mutating "state" member
-        await this.store.saveState(this.state)
+        await this.saveState()
+    }
+    async saveState(){
+        this.store.saveState(this.state)
     }
 
     async stop() {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -2,7 +2,7 @@ const EventEmitter = require("events")
 
 const { Contract, utils } = require("ethers")
 
-const MonoplasmaState = require("monoplasma/src/state")
+const MonoplasmaState = require("./state")
 const { replayOn, mergeEventLists } = require("./utils/events")
 const { throwIfSetButNotContract, throwIfSetButBadAddress } = require("./utils/checkArguments")
 const bisectFindFirstIndex = require("./utils/bisectFindFirstIndex")

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -124,7 +124,7 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
         this.blockCreateFilter = this.contract.filters.BlockCreated()
         this.tokenTransferFilter = this.token.filters.Transfer(null, this.contract.address)
 
-//        let lastPublishedBlockNumber = this.state.lastPublishedBlock && this.state.lastPublishedBlock.blockNumber
+        // let lastPublishedBlockNumber = this.state.lastPublishedBlock && this.state.lastPublishedBlock.blockNumber
         let lastBlock = {
             members: [],
             blockNumber: 0,
@@ -141,9 +141,9 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
             lastBlock = await this.store.loadBlock(lastPublishedBlockNumber)
         }
         */
-       if(await this.store.hasLatestBlock()){
-           lastBlock = await this.store.getLatestBlock()
-       }
+        if (await this.store.hasLatestBlock()){
+            lastBlock = await this.store.getLatestBlock()
+        }
         this.log(`Starting from block ${lastBlock.blockNumber} (t=${lastBlock.timestamp}, ${new Date((lastBlock.timestamp || 0) * 1000).toISOString()}) with ${lastBlock.members.length} members`)
         this.plasma = new MonoplasmaState(this.state.blockFreezeSeconds, lastBlock.members, this.store, this.state.adminAddress, this.state.adminFee, lastBlock.blockNumber, lastBlock.timestamp)
 

--- a/test/system/engine-and-editor-api.js
+++ b/test/system/engine-and-editor-api.js
@@ -287,8 +287,7 @@ describe("Community product demo but through a running E&E instance", () => {
             await sleep(1000)
             member = await GET(`/communities/${communityAddress}/members/${address}`)
         }
-        log("    member:", member)
-        sleep(3000) // unfreeze?
+        log("    Member before", member)
 
         log("4) Withdraw tokens")
 
@@ -297,10 +296,12 @@ describe("Community product demo but through a running E&E instance", () => {
 
         const contract = new Contract(communityAddress, CommunityProduct.abi, wallet)
         const withdrawTx = await contract.withdrawAll(member.withdrawableBlockNumber, member.withdrawableEarnings, member.proof)
+        log("    withdrawAll done")
         await withdrawTx.wait(2)
+        log("    withdrawAll confirmed")
 
         const res4b = await GET(`/communities/${communityAddress}/members/${address}`)
-        Object.keys(res4b).forEach(k => log(`    ${k} ${JSON.stringify(res4b[k])}`))
+        log("    member stats after", res4b)
 
         const balanceAfter = await token.balanceOf(address)
         log(`   Token balance after: ${formatEther(balanceAfter)}`)
@@ -311,16 +312,19 @@ describe("Community product demo but through a running E&E instance", () => {
         log("4.1) Withdraw tokens for another account")
         const address2 = members[1].address // 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
         const member2 = await GET(`/communities/${communityAddress}/members/${address2}`)
+        log("    Member2 stats before", res4b)
         Object.keys(member2).forEach(k => log(`    ${k} ${JSON.stringify(member2[k])}`))
 
         const balanceBefore2 = await token.balanceOf(address2)
         log(`   Token balance before: ${formatEther(balanceBefore2)}`)
-        
+
         const withdrawTx2 = await contract.withdrawAllFor(address2, member2.withdrawableBlockNumber, member2.withdrawableEarnings, member2.proof)
+        log("    withdrawAll done")
         await withdrawTx2.wait(2)
+        log("    withdrawAll confirmed")
 
         const res4c = await GET(`/communities/${communityAddress}/members/${address2}`)
-        Object.keys(res4c).forEach(k => log(`    ${k} ${JSON.stringify(res4c[k])}`))
+        log("    Member2 stats after", res4c)
 
         const balanceAfter2 = await token.balanceOf(address2)
         log(`   Token balance after: ${formatEther(balanceAfter2)}`)

--- a/test/system/engine-and-editor-api.js
+++ b/test/system/engine-and-editor-api.js
@@ -279,13 +279,15 @@ describe("Community product demo but through a running E&E instance", () => {
         }
 
         log("3.1) Wait for blocks to unfreeze...") //... and also that state updates.
+
+        const expectedAdminEarnings = parseEther("14").toString()
         let member = memberBeforeRevenues
-        // wait until member.withdrawableEarnings exists && has increased
-        while (member.withdrawableEarnings < 1 + memberBeforeRevenues.withdrawableEarnings) {
+        // wait until member.withdrawableEarnings is at least expected earnings
+        while ((member.withdrawableEarnings - memberBeforeRevenues.withdrawableEarnings) < expectedAdminEarnings) {
             await sleep(1000)
             member = await GET(`/communities/${communityAddress}/members/${address}`)
         }
-        Object.keys(member).forEach(k => log(`    ${k} ${JSON.stringify(member[k])}`))
+        log("    member:", member)
 
         log("4) Withdraw tokens")
 
@@ -325,12 +327,11 @@ describe("Community product demo but through a running E&E instance", () => {
         const difference2 = balanceAfter2.sub(balanceBefore2)
         log(`   Withdraw effect: ${formatEther(difference2)}`)
 
-        const adminEarnings = parseEther("14").toString()
-        const memberEarnings = parseEther("4").toString()
-        assert.strictEqual(member.withdrawableEarnings, adminEarnings)
-        assert.strictEqual(member2.withdrawableEarnings, memberEarnings)
-        assert.strictEqual(difference.toString(), adminEarnings)
-        assert.strictEqual(difference2.toString(), memberEarnings)
+        const expectedMember2Earnings = parseEther("4").toString()
+        assert.strictEqual(member.withdrawableEarnings, expectedAdminEarnings)
+        assert.strictEqual(member2.withdrawableEarnings, expectedMember2Earnings)
+        assert.strictEqual(difference.toString(), expectedAdminEarnings)
+        assert.strictEqual(difference2.toString(), expectedMember2Earnings)
     })
 
     afterEach(() => {

--- a/test/system/engine-and-editor-api.js
+++ b/test/system/engine-and-editor-api.js
@@ -288,6 +288,7 @@ describe("Community product demo but through a running E&E instance", () => {
             member = await GET(`/communities/${communityAddress}/members/${address}`)
         }
         log("    member:", member)
+        sleep(3000) // unfreeze?
 
         log("4) Withdraw tokens")
 
@@ -296,7 +297,7 @@ describe("Community product demo but through a running E&E instance", () => {
 
         const contract = new Contract(communityAddress, CommunityProduct.abi, wallet)
         const withdrawTx = await contract.withdrawAll(member.withdrawableBlockNumber, member.withdrawableEarnings, member.proof)
-        await withdrawTx.wait(1)
+        await withdrawTx.wait(2)
 
         const res4b = await GET(`/communities/${communityAddress}/members/${address}`)
         Object.keys(res4b).forEach(k => log(`    ${k} ${JSON.stringify(res4b[k])}`))

--- a/test/system/engine-and-editor-api.js
+++ b/test/system/engine-and-editor-api.js
@@ -257,7 +257,7 @@ describe("Community product demo but through a running E&E instance", () => {
         log("2.3) Wait until members have been added")
         let members = []
         sleepTime = 100
-        while (members.length < 1) {
+        while (members.length < 2) {
             await sleep(sleepTime *= 2)
             members = await GET(`/communities/${communityAddress}/members`)
         }

--- a/test/unit/communitiesRouter.js
+++ b/test/unit/communitiesRouter.js
@@ -17,7 +17,7 @@ const ganache = require("ganache-core")
 const { until } = require("../utils/await-until")
 
 const MockStreamrChannel = require("../utils/mockStreamrChannel")
-const mockStore = require("monoplasma/test/utils/mockStore")
+const mockStore = require("../utils/mockStore")
 const members = [
     { address: "0x2F428050ea2448ed2e4409bE47e1A50eBac0B2d2", earnings: "50" },
     { address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", earnings: "20" },

--- a/test/unit/fileStore.js
+++ b/test/unit/fileStore.js
@@ -1,0 +1,54 @@
+const os = require("os")
+const path = require("path")
+const assert = require("assert")
+
+const log = require("debug")("Streamr::CPS::test::unit::fileStore")
+
+const tmpDir = path.join(os.tmpdir(), `fileStore-test-${+new Date()}`)
+const FileStore = require("../../src/fileStore")
+const fileStore = new FileStore(tmpDir, log)
+
+describe("File system implementation of Monoplasma storage", () => {
+    it("Correctly loads and saves state", async () => {
+        const saved = {testing: "yes"}
+        await fileStore.saveState(saved)
+        const loaded = await fileStore.loadState()
+        assert.deepStrictEqual(saved, loaded)
+    })
+
+    it("Correctly loads and saves blocks", async () => {
+        const saved = {blockNumber: 42, members: [], timeStamp: +new Date(), totalEarnings: "1"}
+        await fileStore.saveBlock(saved)
+        const exists = await fileStore.blockExists(42)
+        assert(exists)
+        const loaded = await fileStore.loadBlock(42)
+        assert.deepStrictEqual(saved, loaded)
+    })
+
+    it("Checks block existence correctly", async () => {
+        const exists = await fileStore.blockExists(68)
+        assert(!exists)
+    })
+
+    it("Correctly loads and saves events", async () => {
+        await fileStore.saveEvents(42, [
+            { blockNumber: 42, event: "Join", addressList: ["0x6dde58bf01e320de32aa69f6daf9ba3c887b4db6"] },
+            { blockNumber: 42, event: "Join", addressList: ["0x47262e0936ec174b7813941ee57695e3cdcd2043"] },
+        ])
+        await fileStore.saveEvents(44, [
+            { blockNumber: 44, event: "Part", addressList: ["0x6dde58bf01e320de32aa69f6daf9ba3c887b4db6"] },
+            { blockNumber: 44, event: "Part", addressList: ["0x47262e0936ec174b7813941ee57695e3cdcd2043"] },
+        ])
+        await fileStore.saveEvents(46, [
+            { blockNumber: 46, event: "Join", addressList: ["0x6dde58bf01e320de32aa69f6daf9ba3c887b4db6"] },
+            { blockNumber: 46, event: "Join", addressList: ["0x47262e0936ec174b7813941ee57695e3cdcd2043"] },
+        ])
+        const loaded = await fileStore.loadEvents(42, 44)
+        assert.deepStrictEqual(loaded, [
+            { blockNumber: 42, event: "Join", addressList: ["0x6dde58bf01e320de32aa69f6daf9ba3c887b4db6"] },
+            { blockNumber: 42, event: "Join", addressList: ["0x47262e0936ec174b7813941ee57695e3cdcd2043"] },
+            { blockNumber: 44, event: "Part", addressList: ["0x6dde58bf01e320de32aa69f6daf9ba3c887b4db6"] },
+            { blockNumber: 44, event: "Part", addressList: ["0x47262e0936ec174b7813941ee57695e3cdcd2043"] },
+        ])
+    })
+})

--- a/test/unit/member.js
+++ b/test/unit/member.js
@@ -15,7 +15,11 @@ describe("MonoplasmaMember", () => {
     })
     it("should initially be active", () => {
         const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2")
-        assert(m.isActive())
+        assert.strictEqual(m.isActive(), true)
+    })
+    it("should allow active to be specified", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100, false)
+        assert.strictEqual(m.isActive(), false, "should not be active")
     })
     it("should return correct object representation", () => {
         const m = new MonoplasmaMember("tester1", "b3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100)

--- a/test/unit/member.js
+++ b/test/unit/member.js
@@ -1,0 +1,56 @@
+const MonoplasmaMember = require("../../src/member")
+const assert = require("assert")
+const sinon = require("sinon")
+
+describe("MonoplasmaMember", () => {
+    it("should add revenue to initially undefined balance", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2")
+        m.addRevenue(100)
+        assert.strictEqual(m.getEarningsAsInt(), 100)
+    })
+    it("should add revenue to initially defined balance", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100)
+        m.addRevenue(100)
+        assert.strictEqual(m.getEarningsAsInt(), 200)
+    })
+    it("should initially be active", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2")
+        assert(m.isActive())
+    })
+    it("should return correct object representation", () => {
+        const m = new MonoplasmaMember("tester1", "b3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100)
+        const obj = {
+            name: "tester1",
+            address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2",
+            earnings: "100",
+            active: true
+        }
+        assert.deepStrictEqual(m.toObject(), obj)
+    })
+    it("should return correct string data representation (to be hashed in the merkle tree)", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100)
+        const data = "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d20000000000000000000000000000000000000000000000000000000000000064"
+        assert.deepStrictEqual(m.toHashableString(), data)
+    })
+    it("should return empty proof if earnings is zero", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2")
+        assert.deepStrictEqual(m.getProof(), [])
+    })
+    it("should return proof", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100)
+        const tree = {}
+        const proof = ["0x30b397c3eb0e07b7f1b8b39420c49f60c455a1a602f1a91486656870e3f8f74c"]
+        tree.getPath = sinon.stub().returns(proof)
+        assert.deepStrictEqual(m.getProof(tree), proof)
+    })
+    it("should return proof", () => {
+        const m = new MonoplasmaMember("tester1", "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 100)
+        const tree = {}
+        const proof = ["0x30b397c3eb0e07b7f1b8b39420c49f60c455a1a602f1a91486656870e3f8f74c"]
+        tree.getPath = sinon.stub().returns(proof)
+        assert.deepStrictEqual(m.getProof(tree), proof)
+    })
+    it("should throw when invalid address", () => {
+        assert.throws(() => new MonoplasmaMember("tester1", "0xbe47e1ac0b2d2"))
+    })
+})

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -202,6 +202,6 @@ describe("CommunityProductServer", function () {
         server.getChannelFor.callsFake(async function () {
             throw new Error("expected fail")
         })
-        assert.rejects(() => server.start())
+        await assert.rejects(() => server.start())
     })
 })

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -9,7 +9,7 @@ const log = require("debug")("Streamr::CPS::test::unit::server")
 
 const ganache = require("ganache-core")
 
-const mockStore = require("monoplasma/test/utils/mockStore")
+const mockStore = require("../utils/mockStore")
 const MockStreamrChannel = require("../utils/mockStreamrChannel")
 const deployTestToken = require("../utils/deployTestToken")
 const deployTestCommunity = require("../utils/deployTestCommunity")

--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -103,7 +103,7 @@ describe("MonoplasmaState", () => {
         this.timeout(40000)
 
         const initialMembers = []
-        while (initialMembers.length < 200000) {
+        while (initialMembers.length < 150000) {
             initialMembers.push({
                 address: `0x${crypto.randomBytes(20).toString("hex")}`,
                 earnings: 0,
@@ -124,7 +124,7 @@ describe("MonoplasmaState", () => {
         //         each getProofAt on cold cache (new block) takes about 5s
         const startTime = Date.now()
         //for (let j = 0; j < 10; j++) {
-        for (let i = 0; i < 20; i++) {
+        for (let i = 0; i < 15; i++) {
             const bnum = 100 + i % 3
             const { address } = initialMembers[(50 * i) % initialMembers.length]
             await plasma.getProofAt(address, bnum)

--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -99,11 +99,11 @@ describe("MonoplasmaState", () => {
         assert.deepStrictEqual(plasma.getProof("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2"), ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0x91360deed2f511a8503790083c6de21efbb1006b460d5024863ead9de5448927"])
     })
 
-    it("should perform fine with LOTS of members and queries of recent past blocks' proofs", async function() {
-        this.timeout(40000)
-
+    // The idea of this test is to make sure the merkletrees are cached between getProofAt queries
+    //   so that the tree isn't recalculated every time
+    it("should perform fine with LOTS of queries of recent past blocks' proofs", async () => {
         const initialMembers = []
-        while (initialMembers.length < 150000) {
+        while (initialMembers.length < 1000) {
             initialMembers.push({
                 address: `0x${crypto.randomBytes(20).toString("hex")}`,
                 earnings: 0,
@@ -119,17 +119,13 @@ describe("MonoplasmaState", () => {
         await plasma.storeBlock(102, now())
         plasma.addRevenue(100)
 
-        // TODO: use mocha timeouts instead. They didn't seem to work well for CPU bound stuff though...
-        // TODO: make this test actually test what the name says
-        //         each getProofAt on cold cache (new block) takes about 5s
         const startTime = Date.now()
-        //for (let j = 0; j < 10; j++) {
-        for (let i = 0; i < 15; i++) {
+        for (let i = 0; i < 1000; i++) {
             const bnum = 100 + i % 3
             const { address } = initialMembers[(50 * i) % initialMembers.length]
             await plasma.getProofAt(address, bnum)
             const timeTaken = Date.now() - startTime
-            assert(timeTaken < 30000, `${timeTaken} is too slow!`)
+            assert(timeTaken < 5000, "too slow!")
         }
     })
 

--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -1,0 +1,220 @@
+const os = require("os")
+const path = require("path")
+const assert = require("assert")
+const crypto = require("crypto")
+const BN = require("bn.js")
+
+const now = require("monoplasma/src/utils/now")
+const MonoplasmaState = require("../../src/state")
+
+//const sleep = require("../utils/sleep-promise")
+
+// this is a unit test, but still it's better to use the "real" file store and not mock it,
+//   since we DO check that the correct values actually come out of it. Mock would be almost as complex as the real thing.
+const log = require("debug")("Streamr::CPS::test::unit::state")
+const tmpDir = path.join(os.tmpdir(), `monoplasma-test-${+new Date()}`)
+const FileStore = require("../../src/fileStore")
+const fileStore = new FileStore(tmpDir, log)
+const admin = "0x0000000000000000000000000000000000123564"
+
+describe("MonoplasmaState", () => {
+    it("should return member passed to constructor and then remove it successfully", () => {
+        const plasmaAdmin = new MonoplasmaState(0, [{
+            address: "0xff019d79c31114c811e68e68c9863966f22370ef",
+            earnings: 10
+        }], fileStore, admin, 0)
+        assert.deepStrictEqual(plasmaAdmin.getMembers(), [{
+            address: "0xff019d79c31114c811e68e68c9863966f22370ef",
+            earnings: "10",
+            active: true,
+        }])
+        plasmaAdmin.removeMember("0xff019d79c31114c811e68e68c9863966f22370ef")
+        assert.deepStrictEqual(plasmaAdmin.getMembers(), [])
+    })
+
+    it("should return correct members and member count", () => {
+        const plasma = new MonoplasmaState(0, [], fileStore, admin, 0)
+        plasma.addMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "tester1")
+        plasma.addMember("0xe5019d79c3fc34c811e68e68c9bd9966f22370ef", "tester2")
+        plasma.addRevenue(100)
+        assert.deepStrictEqual(plasma.getMemberCount(), { total: 2, active: 2, inactive: 0 })
+        assert.deepStrictEqual(plasma.getMembers(), [
+            {"address": "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "earnings": "50", "name": "tester1", active: true},
+            {"address": "0xe5019d79c3fc34c811e68e68c9bd9966f22370ef", "earnings": "50", "name": "tester2", active: true},
+        ])
+        plasma.removeMember("0xe5019d79c3fc34c811e68e68c9bd9966f22370ef")
+        plasma.addRevenue(100)
+        assert.deepStrictEqual(plasma.getMemberCount(), { total: 2, active: 1, inactive: 1 })
+        assert.deepStrictEqual(plasma.getMembers(), [
+            {"address": "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "earnings": "150", "name": "tester1", active: true},
+        ])
+    })
+
+    it("should not crash with large number of members", () => {
+        const initialMembers = []
+        while (initialMembers.length < 200000) {
+            initialMembers.push({
+                address: `0x${crypto.randomBytes(20).toString("hex")}`,
+                earnings: 0,
+            })
+        }
+        const plasma = new MonoplasmaState(0, initialMembers, fileStore, admin, 0)
+        plasma.addRevenue(100)
+    })
+
+    it("should remember past blocks' earnings", async () => {
+        const plasma = new MonoplasmaState(0, [], fileStore, admin, 0)
+        plasma.addMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "tester1")
+        plasma.addMember("0xe5019d79c3fc34c811e68e68c9bd9966f22370ef", "tester2")
+        plasma.addRevenue(100)
+        await plasma.storeBlock(3, now())
+        plasma.addRevenue(100)
+        await plasma.storeBlock(5, now())
+        plasma.addRevenue(100)
+        plasma.addRevenue(100)
+        await plasma.storeBlock(7, now())
+        plasma.addRevenue(100)
+        const m = await plasma.getMemberAt("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 3)
+        assert.strictEqual("50", m.earnings)
+        assert.strictEqual("100", (await plasma.getMemberAt("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 5)).earnings)
+        assert.strictEqual("200", (await plasma.getMemberAt("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 7)).earnings)
+        assert.strictEqual("250", (plasma.getMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2")).earnings)
+    })
+
+    it("should remember past blocks' proofs", async () => {
+        const plasma = new MonoplasmaState(0, [], fileStore, admin, 0)
+        plasma.addMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "tester1")
+        plasma.addMember("0xe5019d79c3fc34c811e68e68c9bd9966f22370ef", "tester2")
+        plasma.addRevenue(100)
+        await plasma.storeBlock(10, now())
+        plasma.addRevenue(100)
+        await plasma.storeBlock(12, now())
+        plasma.addRevenue(100)
+        plasma.addRevenue(100)
+        await plasma.storeBlock(15, now())
+        plasma.addRevenue(100)
+        assert.deepStrictEqual(await plasma.getProofAt("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 10), ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0x30b397c3eb0e07b7f1b8b39420c49f60c455a1a602f1a91486656870e3f8f74c"])
+        assert.deepStrictEqual(await plasma.getProofAt("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 12), ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0x1c3d277e4a94f6fc647ae9ffc2176165d8b90bf954f64fa536b6beedb34301a3"])
+        assert.deepStrictEqual(await plasma.getProofAt("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", 15), ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0xce54ad18b934665680ccc22f7db77ede2144519d5178736111611e745085dec6"])
+        assert.deepStrictEqual(plasma.getProof("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2"), ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0x91360deed2f511a8503790083c6de21efbb1006b460d5024863ead9de5448927"])
+    })
+
+    it("should perform fine with LOTS of members and queries of recent past blocks' proofs", async function() {
+        this.timeout(40000)
+
+        const initialMembers = []
+        while (initialMembers.length < 200000) {
+            initialMembers.push({
+                address: `0x${crypto.randomBytes(20).toString("hex")}`,
+                earnings: 0,
+            })
+        }
+        const plasma = new MonoplasmaState(0, initialMembers, fileStore, admin, 0)
+        plasma.addRevenue(100)
+        await plasma.storeBlock(100, now())
+        plasma.addRevenue(100)
+        await plasma.storeBlock(101, now())
+        plasma.addRevenue(100)
+        plasma.addRevenue(100)
+        await plasma.storeBlock(102, now())
+        plasma.addRevenue(100)
+
+        // TODO: use mocha timeouts instead. They didn't seem to work well for CPU bound stuff though...
+        // TODO: make this test actually test what the name says
+        //         each getProofAt on cold cache (new block) takes about 5s
+        const startTime = Date.now()
+        //for (let j = 0; j < 10; j++) {
+        for (let i = 0; i < 20; i++) {
+            const bnum = 100 + i % 3
+            const { address } = initialMembers[(50 * i) % initialMembers.length]
+            await plasma.getProofAt(address, bnum)
+        }
+        //  await sleep(100)
+        //}
+        const timeTaken = Date.now() - startTime
+        assert(timeTaken < 30000, "too slow!")
+    })
+
+    it("should give revenue to adminAccount if no members present", async () => {
+        const plasma = new MonoplasmaState(0, [], fileStore, "0x1234567890123456789012345678901234567890", 0)
+        plasma.addRevenue(100)
+        assert.strictEqual(plasma.getMember("0x1234567890123456789012345678901234567890").earnings, "100")
+    })
+    it("should give no revenue to adminAccount if members present", async () => {
+        const plasma = new MonoplasmaState(0, [], fileStore, "0x1234567890123456789012345678901234567890", 0)
+        plasma.addMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "tester1")
+        plasma.addRevenue(100)
+        assert.strictEqual(plasma.getMember("0x1234567890123456789012345678901234567890").earnings, "0")
+    })
+
+    describe("changing the admin fee", () => {
+        it("should accept valid values", () => {
+            const plasma = new MonoplasmaState(0, [], fileStore, admin, 0)
+            plasma.setAdminFeeFraction(0.3)
+            assert.strictEqual(plasma.adminFeeFraction.toString(), "300000000000000000")
+            plasma.setAdminFeeFraction("400000000000000000")
+            assert.strictEqual(plasma.adminFeeFraction.toString(), "400000000000000000")
+            plasma.setAdminFeeFraction(new BN("500000000000000000"))
+            assert.strictEqual(plasma.adminFeeFraction.toString(), "500000000000000000")
+        })
+        it("should not accept numbers from wrong range", () => {
+            const plasma = new MonoplasmaState(0, [], fileStore, admin, 0)
+            assert.throws(() => plasma.setAdminFeeFraction(-0.3))
+            assert.throws(() => plasma.setAdminFeeFraction("-400000000000000000"))
+            assert.throws(() => plasma.setAdminFeeFraction(new BN("-500000000000000000")))
+            assert.throws(() => plasma.setAdminFeeFraction(1.3))
+            assert.throws(() => plasma.setAdminFeeFraction("1400000000000000000"))
+            assert.throws(() => plasma.setAdminFeeFraction(new BN("1500000000000000000")))
+        })
+        it("should not accept bad values", () => {
+            const plasma = new MonoplasmaState(0, [], fileStore, admin, 0)
+            assert.throws(() => plasma.setAdminFeeFraction("bad hex"))
+            assert.throws(() => plasma.setAdminFeeFraction(""))
+            assert.throws(() => plasma.setAdminFeeFraction({}))
+            assert.throws(() => plasma.setAdminFeeFraction(plasma))
+            assert.throws(() => plasma.setAdminFeeFraction())
+        })
+    })
+
+    describe("getMemberApi", () => {
+        let plasma
+        beforeEach(() => {
+            const plasmaAdmin = new MonoplasmaState(0, [], fileStore, admin, 0)
+            plasmaAdmin.addMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", "tester1")
+            plasmaAdmin.addMember("0xe5019d79c3fc34c811e68e68c9bd9966f22370ef", "tester2")
+            plasmaAdmin.addRevenue(100)
+            plasma = plasmaAdmin.getMemberApi()
+        })
+        it("has all read-only functions", async () => {
+            assert.deepStrictEqual(plasma.getMembers(), [{
+                address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2",
+                earnings: "50",
+                name: "tester1",
+                active: true
+            }, {
+                address: "0xe5019d79c3fc34c811e68e68c9bd9966f22370ef",
+                earnings: "50",
+                name: "tester2",
+                active: true
+            }])
+            assert.deepStrictEqual(plasma.getMember("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2"), {
+                name: "tester1",
+                address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2",
+                earnings: "50",
+                proof: ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0x30b397c3eb0e07b7f1b8b39420c49f60c455a1a602f1a91486656870e3f8f74c"],
+                active: true,
+            })
+            assert.strictEqual(plasma.getRootHash(), "0xe259a647fd9c91d31a98daa8185e28181d20ea0aeb9253718b10fcb074794582")
+            assert.deepStrictEqual(
+                plasma.getProof("0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2"),
+                ["0x8620ab3c4df51cebd7ae1cd533c8824220db518d2a143e603e608eab62b169f7", "0x30b397c3eb0e07b7f1b8b39420c49f60c455a1a602f1a91486656870e3f8f74c"],
+            )
+        })
+        it("doesn't have any write functions", () => {
+            assert.strictEqual(plasma.addMember, undefined)
+            assert.strictEqual(plasma.removeMember, undefined)
+            assert.strictEqual(plasma.addRevenue, undefined)
+            assert.strictEqual(plasma.getMemberApi, undefined)
+        })
+    })
+})

--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -128,11 +128,9 @@ describe("MonoplasmaState", () => {
             const bnum = 100 + i % 3
             const { address } = initialMembers[(50 * i) % initialMembers.length]
             await plasma.getProofAt(address, bnum)
+            const timeTaken = Date.now() - startTime
+            assert(timeTaken < 30000, `${timeTaken} is too slow!`)
         }
-        //  await sleep(100)
-        //}
-        const timeTaken = Date.now() - startTime
-        assert(timeTaken < 30000, "too slow!")
     })
 
     it("should give revenue to adminAccount if no members present", async () => {

--- a/test/unit/watcher.js
+++ b/test/unit/watcher.js
@@ -19,7 +19,7 @@ const TokenJson = require("../../build/TestToken")
 const sleep = require("../../src/utils/sleep-promise")
 
 const MockStreamrChannel = require("../utils/mockStreamrChannel")
-const mockStore = require("monoplasma/test/utils/mockStore")
+const mockStore = require("../utils/mockStore")
 
 const members = [
     { address: "0x2F428050ea2448ed2e4409bE47e1A50eBac0B2d2", earnings: "50" },

--- a/test/unit/watcher.js
+++ b/test/unit/watcher.js
@@ -130,8 +130,8 @@ describe("MonoplasmaWatcher", () => {
 
         assert(store.lastSavedState)
         const newBalances = [
-            { address: "0x2F428050ea2448ed2e4409bE47e1A50eBac0B2d2", earnings: "70" }, // 50 startBalance + 10 + 10 (40 -> 20/2, 20 for admin)
-            { address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", earnings: "40" }, // 20 startBalance + 10 + 10
+            { address: "0x2F428050ea2448ed2e4409bE47e1A50eBac0B2d2", earnings: "70", active: true }, // 50 startBalance + 10 + 10 (40 -> 20/2, 20 for admin)
+            { address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", earnings: "40", active: true }, // 20 startBalance + 10 + 10
         ]
         assert.deepStrictEqual(watcher.plasma.getMembers(), newBalances)
     })
@@ -168,10 +168,10 @@ describe("MonoplasmaWatcher", () => {
         await sleep(1000)
         log(JSON.stringify(watcher.plasma.getMembers()))
         const expectedBalances = [
-            { address: "0x2F428050ea2448ed2e4409bE47e1A50eBac0B2d2", earnings: "70" }, // 50 startBalance + 10 + 5 + 5
-            { address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", earnings: "40" }, // 20 startBalance + 10 + 5 + 5
-            { address: "0x1234567812345678123456781234567812345678", earnings: "10" }, // 0 startBalance + 5 + 5
-            { address: "0x2234567812345678123456781234567812345678", earnings: "5" }, // 0 startBalance + 5
+            { address: "0x2F428050ea2448ed2e4409bE47e1A50eBac0B2d2", earnings: "70", active: true }, // 50 startBalance + 10 + 5 + 5
+            { address: "0xb3428050ea2448ed2e4409be47e1a50ebac0b2d2", earnings: "40", active: true }, // 20 startBalance + 10 + 5 + 5
+            { address: "0x1234567812345678123456781234567812345678", earnings: "10", active: true }, // 0 startBalance + 5 + 5
+            { address: "0x2234567812345678123456781234567812345678", earnings: "5", active: true }, // 0 startBalance + 5
         ]
         assert.deepStrictEqual(watcher.plasma.getMembers(), expectedBalances)
 

--- a/test/utils/mockStore.js
+++ b/test/utils/mockStore.js
@@ -1,0 +1,32 @@
+module.exports = function getMockStore(mockState, mockBlock, logFunc) {
+    const log = logFunc || (() => {})
+    const store = {
+        events: [],
+    }
+    store.saveState = async state => {
+        log(`Saving state: ${JSON.stringify(state)}`)
+        store.lastSavedState = state
+    }
+    store.saveBlock = async (data) => {
+        log(`Saving block ${data.blockNumber}: ${JSON.stringify(data)}`)
+        store.lastSavedBlock = data
+    }
+    store.loadState = async () => Object.assign({}, mockState)
+    store.loadBlock = async () => Object.assign({}, mockBlock)
+    store.blockExists = async () => true
+    store.loadEvents = async () => store.events
+    store.saveEvents = async (bnum, event) => {
+        store.events.push(event)
+    }
+
+    store.hasLatestBlock = async () => {
+        return true
+    }
+
+    store.getLatestBlock = async () => {
+        return store.loadBlock()
+    }
+
+    return store
+}
+


### PR DESCRIPTION
- pulled in state.js and member.js from Monoplasma to CP repo
- fixed serialization of "active" and "name" fields in member

amended tests to include "active" flag in https://github.com/streamr-dev/streamr-client-javascript/tree/CPS-35-community-endpoints

There are 2 commits. First commit is unmodified state.js and member.js. Second commit has the bug fixes so you can compare diff.