### PR TITLE
Add 'Streamr' prefix to debug logs.

### DIFF
--- a/src/operator.js
+++ b/src/operator.js
@@ -20,7 +20,7 @@ module.exports = class MonoplasmaOperator {
 
     async start(config) {
         throwIfBadAddress(config.operatorAddress, "MonoplasmaOperator argument config.operatorAddress")
-        this.log = debug("CPS::operator::" + config.contractAddress)
+        this.log = debug("Streamr::CPS::operator::" + config.contractAddress)
 
         this.finalityWaitPeriodSeconds = config.finalityWaitPeriodSeconds || 1 // TODO: in production || 3600
         this.address = config.operatorAddress
@@ -105,7 +105,7 @@ module.exports = class MonoplasmaOperator {
         // await this.finalPlasma.storeBlock(blockNumber) // TODO: give a timestamp
         await this.watcher.plasma.storeBlock(blockNumber)
         const tr = await tx.wait(1)        // confirmations
-        debug(`Commit sent, receipt: ${JSON.stringify(tr)}`)
+        this.log(`Commit sent, receipt: ${JSON.stringify(tr)}`)
 
         // TODO: something causes events to be replayed many times, resulting in wrong balances. It could have something to do with the state cloning that happens here
         // replace watcher's MonoplasmaState with the final "true" state that was just committed to blockchain

--- a/src/routers/communities.js
+++ b/src/routers/communities.js
@@ -3,7 +3,7 @@ const {
     utils: { getAddress, BigNumber }
 } = require("ethers")
 
-const log = require("debug")("CPS::routers::communities")
+const log = require("debug")("Streamr::CPS::routers::communities")
 
 /** Convert Ethereum address into checksummed case */
 function parseAddress(address) {

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ const {
     utils: { id, getAddress, hexZeroPad, Interface }
 } = require("ethers")
 
+const debug = require("debug")
 const FileStore = require("monoplasma/src/fileStore")
 
 const MonoplasmaOperator = require("./operator")
@@ -34,7 +35,7 @@ module.exports = class CommunityProductServer {
 
         this.wallet = wallet
         this.eth = wallet.provider
-        this.log = log || require("debug")("CPS::server")   // TODO: don't pass log func in constructor
+        this.log = log || debug("Streamr::CPS::server")   // TODO: don't pass log func in constructor
         this.error = error || console.error // eslint-disable-line no-console
         this.communities = {}       // mapping: Ethereum address => Community object
         this.storeDir = storeDir

--- a/src/utils/deployCommunity.js
+++ b/src/utils/deployCommunity.js
@@ -4,7 +4,7 @@ const {
 } = require("ethers")
 const StreamrClient = require("streamr-client")
 
-const log = require("debug")("CPS::utils::deployCommunity")
+const log = require("debug")("Streamr::CPS::utils::deployCommunity")
 
 const { throwIfBadAddress, throwIfNotContract } = require("./checkArguments")
 

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,6 +1,6 @@
 const BN = require("bn.js")
 
-const log = require("debug")("CPS::utils::events")
+const log = require("debug")("Streamr::CPS::utils::events")
 
 async function replayOn(plasma, events, messages) {
     const merged = mergeEventsWithMessages(events, messages)

--- a/src/validator.js
+++ b/src/validator.js
@@ -21,7 +21,7 @@ module.exports = class MonoplasmaValidator {
 
     async start(config) {
         throwIfBadAddress(config.operatorAddress, "MonoplasmaOperator argument config.operatorAddress")
-        this.log = debug("CPS::validator::" + config.contractAddress)
+        this.log = debug("Streamr::CPS::validator::" + config.contractAddress)
 
         this.contract = new Contract(config.contractAddress, MonoplasmaJson.abi, this.wallet)
         await this.watcher.start(config)

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -10,7 +10,7 @@ const bisectFindFirstIndex = require("./utils/bisectFindFirstIndex")
 const TokenJson = require("../build/ERC20Mintable.json")
 const MonoplasmaJson = require("../build/Monoplasma.json")
 
-const debug = require("debug")
+const log = require("debug")("Streamr::CPS::watcher")
 
 // TODO: this typedef is foobar. How to get the real thing with JSDoc?
 /** @typedef {number} BigNumber */
@@ -86,7 +86,7 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
      */
     async start(config) {
         await throwIfSetButNotContract(this.eth, config.contractAddress, "contractAddress from initial config")
-        this.log = debug("CPS::watcher::" + config.contractAddress)
+        this.log = log.extend(config.contractAddress)
 
         // TODO: this isn't even used; maybe should throw if it's different from what contract gives?
         throwIfSetButBadAddress(config.adminAddress, "adminAddress from initial config")

--- a/test/contracts/CommunityProduct.js
+++ b/test/contracts/CommunityProduct.js
@@ -1,6 +1,6 @@
 /*global accounts assert utils */
 
-const log = require("debug")("CPS::test::contracts::CommunityProduct")
+const log = require("debug")("Streamr::CPS::test::contracts::CommunityProduct")
 
 const etherlime = require("etherlime")
 const CommunityProduct = require("../../build/CommunityProduct.json")

--- a/test/integration/channel-runner.js
+++ b/test/integration/channel-runner.js
@@ -1,7 +1,7 @@
 const path = require("path")
 const { spawn } = require("child_process")
 
-const log = require("debug")("CPS::test::integration::channel")
+const log = require("debug")("Streamr::CPS::test::integration::channel")
 
 const { STREAMR_WS_URL, STREAMR_HTTP_URL } = require("./CONFIG")
 

--- a/test/integration/deploy-community.js
+++ b/test/integration/deploy-community.js
@@ -2,7 +2,7 @@ const fetch = require("node-fetch")
 const { spawn } = require("child_process")
 const assert = require("assert")
 
-const log = require("debug")("CPS::test::integration::deploy-community-script")
+const log = require("debug")("Streamr::CPS::test::integration::deploy-community-script")
 
 const {
     Contract,

--- a/test/system/community-product-demo.js
+++ b/test/system/community-product-demo.js
@@ -2,7 +2,7 @@ const { spawn } = require("child_process")
 const fetch = require("node-fetch")
 const assert = require("assert")
 
-const log = require("debug")("CPS::test::system::localhost")
+const log = require("debug")("Streamr::CPS::test::system::localhost")
 
 const {
     Contract,

--- a/test/system/demo-using-client.js
+++ b/test/system/demo-using-client.js
@@ -2,7 +2,7 @@ const { spawn } = require("child_process")
 const fetch = require("node-fetch")
 const assert = require("assert")
 
-const log = require("debug")("CPS::test::system::streamr-client")
+const log = require("debug")("Streamr::CPS::test::system::streamr-client")
 
 const StreamrClient = require("streamr-client")
 

--- a/test/system/engine-and-editor-api.js
+++ b/test/system/engine-and-editor-api.js
@@ -2,7 +2,7 @@ const { spawn } = require("child_process")
 const fetch = require("node-fetch")
 const assert = require("assert")
 
-const log = require("debug")("CPS::test::system::http-api")
+const log = require("debug")("Streamr::CPS::test::system::http-api")
 
 const StreamrClient = require("streamr-client") // just for getting session tokens (ethereum-sign-in)...
 

--- a/test/system/revenue-sharing-demo.js
+++ b/test/system/revenue-sharing-demo.js
@@ -2,7 +2,7 @@ const { spawn } = require("child_process")
 const fetch = require("node-fetch")
 const assert = require("assert")
 
-const log = require("debug")("CPS::test::system::operator-demo")
+const log = require("debug")("Streamr::CPS::test::system::operator-demo")
 
 const {
     Contract,

--- a/test/unit/communitiesRouter.js
+++ b/test/unit/communitiesRouter.js
@@ -7,7 +7,7 @@ const http = require("http")
 const fetch = require("node-fetch")
 const { Wallet, ContractFactory, providers: { Web3Provider } } = require("ethers")
 
-const log = require("debug")("CPS::test::unit::communities-router")
+const log = require("debug")("Streamr::CPS::test::unit::communities-router")
 
 const CommunityJson = require("../../build/CommunityProduct")
 const TokenJson = require("../../build/TestToken")

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -5,7 +5,7 @@ const os = require("os")
 const path = require("path")
 const { Wallet, providers: { Web3Provider } } = require("ethers")
 
-const log = require("debug")("CPS::test::unit::server")
+const log = require("debug")("Streamr::CPS::test::unit::server")
 
 const ganache = require("ganache-core")
 

--- a/test/unit/watcher.js
+++ b/test/unit/watcher.js
@@ -1,7 +1,7 @@
 const sinon = require("sinon")
 const assert = require("assert")
 
-const log = require("debug")("CPS::test::unit::watcher")
+const log = require("debug")("Streamr::CPS::test::unit::watcher")
 
 const {
     Wallet,


### PR DESCRIPTION
Other streamr properties use a `"Streamr"` prefix with `debug`, this allows `DEBUG=Streamr*` env to show *all* Streamr logging without having to know/list each project's chosen prefix.

minor.