### PR TITLE
Forward failed community startup errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./scripts/start_server.js",
   "scripts": {
     "start": "node ./scripts/start_server.js",
+    "inspect": "node --inspect-brk ./scripts/start_server.js",
     "lint": "eslint src test scripts",
     "flatten": "etherlime --solcVersion=0.4.24 flatten CommunityProduct.sol",
     "build-contracts": "etherlime --solcVersion=0.4.24 compile",

--- a/src/operator.js
+++ b/src/operator.js
@@ -56,7 +56,7 @@ module.exports = class MonoplasmaOperator {
 
     async shutdown() {
         this.log("Shutting down operator for contract: " + this.watcher.state.contractAddress)
-        this.watcher.stop()
+        await this.watcher.stop()
     }
 
     // TODO: block publishing should be based on value-at-risk, that is, publish after so-and-so many tokens received

--- a/src/server.js
+++ b/src/server.js
@@ -64,7 +64,7 @@ module.exports = class CommunityProductServer {
         this.communityIsRunningPromises = {}
         this.eth.removeAllListeners({ topics: [operatorChangedEventTopic] })
         await Promise.all(Object.values(communities).map((community) => (
-            community.operator.shutdown()
+            community.operator && community.operator.shutdown()
         )))
     }
 

--- a/src/streamrChannel.js
+++ b/src/streamrChannel.js
@@ -147,6 +147,10 @@ module.exports = class StreamrChannel extends EventEmitter {
         this.mode = State.CLIENT
     }
 
+    isClosed() {
+        return this.mode === State.CLOSED
+    }
+
     /** Close the channel */
     async close() {
         if (this.mode === State.CLOSED) { throw new Error("Can't close, already closed")}

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -213,7 +213,7 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
 
     async stop() {
         //this.tokenFilter.unsubscribe()
-        this.channel.close()
+        await this.channel.close()
     }
 
     /**

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -31,7 +31,8 @@ const startState = {
 }
 
 const CommunityProductServer = require("../../src/server")
-describe("CommunityProductServer", () => {
+describe("CommunityProductServer", function () {
+    this.timeout(10000)
     let tokenAddress
     let wallet
 
@@ -53,8 +54,6 @@ describe("CommunityProductServer", () => {
     })
 
     it("notices creation of a new CommunityProduct and starts Operator", async function () {
-        this.timeout(100000)
-
         log("Starting CommunityProductServer...")
         const storeDir = path.join(os.tmpdir(), `communitiesRouter-test2-${+new Date()}`)
         const config = {
@@ -89,8 +88,6 @@ describe("CommunityProductServer", () => {
     })
 
     it("stops operators when server is stopped", async function () {
-        this.timeout(10000)
-
         log("Starting CommunityProductServer...")
         const storeDir = path.join(os.tmpdir(), `communitiesRouter-test2-${+new Date()}`)
         const config = {
@@ -119,8 +116,6 @@ describe("CommunityProductServer", () => {
     })
 
     it("resumed operating communities it's operated before (e.g. a crash)", async function () {
-        this.timeout(10000)
-
         log("Starting CommunityProductServer...")
         const storeDir = path.join(os.tmpdir(), `communitiesRouter-test1-${+new Date()}`)
         const config = {
@@ -150,8 +145,6 @@ describe("CommunityProductServer", () => {
     })
 
     it("will not fail to start if there is an error playing back a community", async function () {
-        this.timeout(10000)
-
         log("Starting CommunityProductServer...")
         const storeDir = path.join(os.tmpdir(), `communitiesRouter-test1-${+new Date()}`)
         const config = {
@@ -186,7 +179,6 @@ describe("CommunityProductServer", () => {
     })
 
     it("will fail to start if there is an error playing back all communities", async function () {
-        this.timeout(10000)
         const storeDir = path.join(os.tmpdir(), `communitiesRouter-test1-${+new Date()}`)
         const config = {
             tokenAddress,

--- a/test/utils/mockStreamrChannel.js
+++ b/test/utils/mockStreamrChannel.js
@@ -26,6 +26,7 @@ module.exports = class MockStreamrChannel {
         })
         this.mode = "client"
     }
+    isClosed() { return this.mode === "" }
     close() { this.mode = "" }
     publish(type, ...args) {
         this.publishAt(Date.now(), type, ...args)


### PR DESCRIPTION
The startup code looks like it wants to crash if there's faulty communities during playback:

https://github.com/streamr-dev/streamr-community-products/blob/adf07f89832db8b61cbebb356edbe89c6159b3b7/src/server.js#L88-L100

However such failures don't appear to be propagated currently because there's nothing inside the `server.start` awaiting errors coming from `this.communityIsRunningPromises[address].setFailed(error)`.

This PR returns `isCommunityStarted` from `onOperatorChangedEventAt`, allowing propagation of rejections such as `Faulty StreamrChannel` during community startup. This then allows the server to crash as seems to be in the intent in:

https://github.com/streamr-dev/streamr-community-products/blob/adf07f89832db8b61cbebb356edbe89c6159b3b7/src/server.js#L98-L99

I have added a test around this that simulates a faulty channel in order to trigger the error pathway.

----

I've also expanded on `server.stop()` to (try) stop the operators, close channels & tidy up internal `server` state.  The internal state cleanup was required to get `communityIsRunningPromises` to reject on subsequent calls to `start()`. There's more work to do to get everything fully cleaned up and to handle partial state transitions, but it's better now, IMO.

----

Going forward, I'm not sure the server should actually crash, instead it should probably continue to try start the other communities, and even then, starting and reporting that the community has errored is probably better behaviour than the server simply getting stuck in a restart loop. ~~We could address that here or in another PR.~~ Addressing here.

*update*:  Changed the behaviour so that the server will only fail to `start()` if all (> 0) communities fail to start.