### PR TITLE
Replay operator changed events with concurrency 6.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20847,6 +20847,14 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-2.1.0.tgz",
+      "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
+      "requires": {
+        "p-map": "^2.0.0"
+      }
+    },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
@@ -20882,6 +20890,11 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-timeout": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "monoplasma": "0.1.10",
     "morgan": "1.9.1",
     "mz": "2.7.0",
+    "p-all": "2.1.0",
     "streamr-client": "3.0.1"
   },
   "devDependencies": {

--- a/test/system/engine-and-editor-api.js
+++ b/test/system/engine-and-editor-api.js
@@ -287,6 +287,7 @@ describe("Community product demo but through a running E&E instance", () => {
             member = await GET(`/communities/${communityAddress}/members/${address}`)
         }
         log("    member:", member)
+        sleep(3000) // unfreeze?
 
         log("4) Withdraw tokens")
 
@@ -295,7 +296,7 @@ describe("Community product demo but through a running E&E instance", () => {
 
         const contract = new Contract(communityAddress, CommunityProduct.abi, wallet)
         const withdrawTx = await contract.withdrawAll(member.withdrawableBlockNumber, member.withdrawableEarnings, member.proof)
-        await withdrawTx.wait(1)
+        await withdrawTx.wait(2)
 
         const res4b = await GET(`/communities/${communityAddress}/members/${address}`)
         Object.keys(res4b).forEach(k => log(`    ${k} ${JSON.stringify(res4b[k])}`))


### PR DESCRIPTION
Builds on top of "pull in monoplasma fix tests" PR in #32.

Calls `onOperatorChangedEventAt` once for each *unique* contract address found in the operator changed logs. This should decrease startup time by a factor of at least six.

Uses [`p-all`](https://github.com/sindresorhus/p-all) to limit the amount of concurrency; I saw the entire system lock up when trying to replay 40+ events in parallel. I have yet been unsuccessful in reproducing this failure but I have left the concurrency limit in there for good measure.