### PR TITLE
Add /dataunions route, deprecate /communities

### DIFF
--- a/scripts/start_server.js
+++ b/scripts/start_server.js
@@ -137,7 +137,11 @@ async function start() {
         app.use(bodyParser.json({limit: "50mb"}))
 
         app.get("/config", (req, res) => { res.send(config) }) // TODO: remove
-        app.use("/communities", getCommunitiesRouter(server))
+
+        const communitiesRouter = getCommunitiesRouter(server)
+        app.use("/dataunions", communitiesRouter)
+        app.use("/communities", communitiesRouter) // deprecated alias, remove once no longer used
+
         app.listen(port, () => log(`Web server started at ${serverURL}`))
 
         // TODO: remove after 0.2 refactor is done


### PR DESCRIPTION
Community Products is being renamed to Data Unions. This leads to API changes and code changes.

This is a minimal PR that only adds the `/dataunions` route as an alias to `/communities`, which is deprecated. No renaming of classes, variables, or such is included in this PR.

Once this PR is landed, tests on [this `engine-and-editor` PR](https://github.com/streamr-dev/engine-and-editor/pull/736) should pass.