### PR TITLE
Member earnings are 0 when added revenue < number of members.

### DIFF
--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -62,7 +62,7 @@ describe("MonoplasmaState", () => {
         plasma.addRevenue(100)
     })
 
-    it.only("should distribute earnings correctly when revenue < number of members", () => {
+    it("should distribute earnings correctly", () => {
         const initialMembers = []
         while (initialMembers.length < 100) {
             initialMembers.push({
@@ -70,31 +70,60 @@ describe("MonoplasmaState", () => {
                 earnings: 0,
             })
         }
-        const plasma1 = new MonoplasmaState(0, initialMembers, fileStore, admin, 0)
-        assert(plasma1.getMembers().every((m) => (
+        const plasma = new MonoplasmaState(0, initialMembers, fileStore, admin, 0)
+        assert(plasma.getMembers().every((m) => (
             m.earnings === "0"
         )), "all members should have zero earnings")
+
+        // minimum amount of revenue that will result in members receiving earnings
         const revenue = initialMembers.length
-        plasma1.addRevenue(revenue)
-        assert(plasma1.getMembers().every((m) => (
-            m.earnings !== "0"
-        )), "all members should have non-zero earnings")
-        assert.equal(plasma1.getTotalRevenue(), revenue, "total revenue should be what we added")
-        const plasma2 = new MonoplasmaState(0, initialMembers, fileStore, admin, 0)
-        assert(plasma2.getMembers().every((m) => (
+        plasma.addRevenue(revenue)
+        assert(plasma.getMembers().every((m) => (
+            m.earnings === "1"
+        )), "all members should have 1 earnings")
+
+        assert.equal(plasma.getTotalRevenue(), revenue, "total revenue should be what was added")
+
+        // add more revenue
+        plasma.addRevenue(revenue)
+
+        assert(plasma.getMembers().every((m) => (
+            m.earnings === "2"
+        )), "all members should have 2 earnings")
+        assert.equal(plasma.getTotalRevenue(), revenue * 2, "total revenue should be what was added")
+    })
+
+    it("does not give earnings if added revenue < members.length", () => {
+        // if the shared revenue isn't > 0 then it's burned
+        // expected behaviour and isn't significant due to
+        // amount burned being negligable e.g. $0.000000000000000001
+        const initialMembers = []
+        while (initialMembers.length < 100) {
+            initialMembers.push({
+                address: `0x${crypto.randomBytes(20).toString("hex")}`,
+                earnings: 0,
+            })
+        }
+        const plasma = new MonoplasmaState(0, initialMembers, fileStore, admin, 0)
+        assert(plasma.getMembers().every((m) => (
             m.earnings === "0"
         )), "all members should have zero earnings")
-        plasma2.addRevenue(revenue / 2)
-        plasma2.addRevenue(revenue / 2)
-        assert.equal(plasma1.getTotalRevenue(), revenue, "total revenue should be all of what we added")
-        assert(plasma2.getMembers().every((m) => (
-            m.earnings !== "0"
-        )), "all members should have non-zero earnings")
-        const p1Members = plasma1.getMembers()
-        const p2Members = plasma2.getMembers()
-        assert(p1Members.every((m, i) => (
-            m.earnings === p2Members[i].earnings
-        )), "adding same total revenue over multiple transactions should give same member earnings")
+        // largest amount of revenue that can be added that will result in no earnings.
+        const revenue = initialMembers.length - 1
+        plasma.addRevenue(revenue)
+        assert(plasma.getMembers().every((m) => (
+            m.earnings === "0"
+        )), "all members should still have 0 earnings")
+        // note total revenue may not equal total member earnings due to precision loss
+        assert.equal(plasma.getTotalRevenue(), revenue, "total revenue should be what was added")
+
+        // add more revenue that will be burned
+        plasma.addRevenue(revenue)
+        assert(plasma.getMembers().every((m) => (
+            m.earnings === "0"
+        )), "all members should still have 0 earnings")
+
+        assert.equal(plasma.getTotalRevenue(), revenue * 2, "total revenue should be what was added")
     })
 
     it("should remember past blocks' earnings", async () => {


### PR DESCRIPTION
So I’m noticing something a bit funny with reported member earnings. Maybe it’s by design, the values are too small to worry about, or there's something else going on that I don't see yet but:

1. Let’s say we have a community with 100 members and zero admin fee.
2. if I add 100 revenue to this community
3. Community reports 100 total revenue. Good
4. Revenue gets distributed evenly, everyone gets 1 revenue. 

This makes sense to me. But if this revenue is added in two parts, then things get weird
e.g. 
1. create a new community
2. add *50* revenue to the community, then
3. add another *50* revenue
4. This new community reports 100 total revenue, which makes sense.
5. but **all of the members earnings are reported as 0**?

Is this correct?

This discrepancy with the member earnings seems to occur when the added revenue < number of members i.e. the members shared earning would be < 1. 

Perhaps this is unlikely to happen in practice, since community sizes are generally going to be far smaller than the revenue amounts, and there's of course limitations with the level of precision we can handle. Perhaps it's accounted for in the contract itself? Or perhaps this should simply be an error: refuse to add revenue when revenue share would be < 1. 

Otherwise, is this left over value simply lost?

Added a non-pseudocode version of the below as a failing test in 876723f .

```js
// pseudo code
const NUM_MEMBERS = 100
const community1 = createCommunity(NUM_MEMBERS)
community1.addRevenue(NUM_MEMBERS)
assert(community1.getTotalRevenue() == NUM_MEMBERS) // true
assert(community1.members.every(member => member.earnings == 1)) // true

const community2 = createCommunity(NUM_MEMBERS)
community2.addRevenue(NUM_MEMBERS / 2)
community2.addRevenue(NUM_MEMBERS / 2)
assert(community2.getTotalRevenue() == NUM_MEMBERS) // true
assert(community2.members.every(member => member.earnings == 1)) // false ???
```

----

Also curious what happens to the remainder left over after rounding.

e.g. say a community has 4 members and 10 revenue is added.

`10/4 = 2.5`

Would have to round down, because you don't have 3*4 revenue to share, so each member would get 2 revenue? which consumes 8 of the 10 added, but now there's a full 2 units left over. What happens to those?

----

I'm guessing the answer to all this is that the amounts being transferred in practice are so large and the amount lost due to precision is so small that it's just not worth worrying about? And that while the error  will add up over time, the discrepancy between total earnings and the members' earnings won't be as simple to spot as  `revenue total/member count` because of members being added and removed?


---- 

**update**

Ok yeah this is almost definitely a non-problem, the revenue unit is Wei and that even if the rounding error ends up accumulating into the billions, nobody is going to miss it.